### PR TITLE
fix(core): list() and getInstalledSkill() now check canonical directory

### DIFF
--- a/.cursor/rules/development.md
+++ b/.cursor/rules/development.md
@@ -138,6 +138,37 @@ describe('SkillManager', () => {
 2. **Integration Tests** - Test module interactions (skip network tests with `it.skip`)
 3. **Edge Cases** - Test error conditions and boundary values
 
+### Bug Fix Protocol (TDD Approach)
+
+All bug fixes MUST follow this protocol:
+
+1. **Reproduce First** - Write a failing test that reproduces the bug before writing any fix code
+2. **Fix the Bug** - Implement the minimal fix to make the test pass
+3. **Verify with Test** - Ensure the test passes after the fix
+4. **Regression Prevention** - The test serves as a regression guard for future changes
+
+```typescript
+// Example: Bug fix test pattern
+describe('SkillManager', () => {
+  describe('bug fixes', () => {
+    it('should list skills from canonical directory (.agents/skills/)', () => {
+      // This test was added to reproduce issue #XXX
+      // Bug: list() was checking .skills/ instead of .agents/skills/
+      
+      // Setup: Create skill in canonical location
+      // Action: Call list()
+      // Assert: Skill should be found
+    });
+  });
+});
+```
+
+**Why this matters:**
+- Ensures the bug is actually fixed, not just the symptom
+- Prevents the same bug from reappearing
+- Documents the bug and its fix in code
+- Provides confidence when refactoring
+
 ## Project Architecture
 
 See `.cursor/ARCHITECTURE.md` for detailed architecture documentation.

--- a/src/cli/commands/link.test.ts
+++ b/src/cli/commands/link.test.ts
@@ -39,7 +39,8 @@ describe('link command', () => {
 
     await linkCommand.parseAsync(['node', 'test', localSkillDir]);
 
-    const linkedPath = path.join(tempDir, '.skills', 'my-local-skill');
+    // Links are now created in canonical location (.agents/skills/)
+    const linkedPath = path.join(tempDir, '.agents', 'skills', 'my-local-skill');
     expect(fs.existsSync(linkedPath)).toBe(true);
     expect(fs.lstatSync(linkedPath).isSymbolicLink()).toBe(true);
   });
@@ -51,7 +52,8 @@ describe('link command', () => {
 
     await linkCommand.parseAsync(['node', 'test', localSkillDir, '--name', 'custom-name']);
 
-    const linkedPath = path.join(tempDir, '.skills', 'custom-name');
+    // Links are now created in canonical location (.agents/skills/)
+    const linkedPath = path.join(tempDir, '.agents', 'skills', 'custom-name');
     expect(fs.existsSync(linkedPath)).toBe(true);
   });
 });
@@ -80,18 +82,33 @@ describe('unlink command', () => {
     expect(unlinkCommand.name()).toBe('unlink');
   });
 
-  it('should unlink linked skill', async () => {
-    // Create a local skill and link it
+  it('should unlink linked skill from canonical location', async () => {
+    // Create a local skill and link it in canonical location
     const localSkillDir = path.join(tempDir, 'local-skill');
     fs.mkdirSync(localSkillDir);
     fs.writeFileSync(path.join(localSkillDir, 'SKILL.md'), '# Skill');
 
-    const skillsDir = path.join(tempDir, '.skills');
-    fs.mkdirSync(skillsDir);
+    const skillsDir = path.join(tempDir, '.agents', 'skills');
+    fs.mkdirSync(skillsDir, { recursive: true });
     fs.symlinkSync(localSkillDir, path.join(skillsDir, 'my-skill'), 'dir');
 
     await unlinkCommand.parseAsync(['node', 'test', 'my-skill']);
 
     expect(fs.existsSync(path.join(skillsDir, 'my-skill'))).toBe(false);
+  });
+
+  it('should unlink linked skill from legacy location', async () => {
+    // Create a local skill and link it in legacy location
+    const localSkillDir = path.join(tempDir, 'local-skill');
+    fs.mkdirSync(localSkillDir);
+    fs.writeFileSync(path.join(localSkillDir, 'SKILL.md'), '# Skill');
+
+    const skillsDir = path.join(tempDir, '.skills');
+    fs.mkdirSync(skillsDir, { recursive: true });
+    fs.symlinkSync(localSkillDir, path.join(skillsDir, 'legacy-skill'), 'dir');
+
+    await unlinkCommand.parseAsync(['node', 'test', 'legacy-skill']);
+
+    expect(fs.existsSync(path.join(skillsDir, 'legacy-skill'))).toBe(false);
   });
 });


### PR DESCRIPTION
Bug: list() was only checking .skills/ directory, but installToAgents() installs skills to .agents/skills/ (canonical location). This caused list and info commands to report "No skills installed" after installation.

Changes:
- Add getCanonicalSkillsDir() method returning .agents/skills/
- Update getSkillPath() to check canonical location first, fallback to legacy
- Update list() to scan both canonical and legacy directories with dedup
- Add getInstalledSkillFromPath() helper to avoid code duplication
- Update link() to use path.dirname(linkPath) for directory creation

Also adds Bug Fix Protocol to development.md requiring TDD approach: reproduce with test → fix → verify with test