### PR TITLE
fix: correct malformed header in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-/install-github-app# CLAUDE.md
+# CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 


### PR DESCRIPTION
## 问题描述
CLAUDE.md 文件的标题行包含多余的文本 `/install-github-app# CLAUDE.md`，导致 Markdown 格式不正确。

## 解决方案
- ✅ 修正标题行为标准的 Markdown 格式：`# CLAUDE.md`
- ✅ 确保文档格式规范，便于阅读和解析

## 影响范围
- 纯文档修复，不影响功能
- 改善 CLAUDE.md 文档的可读性
- 符合 Markdown 标准格式

## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 破坏性变更  
- [x] 文档更新

这是一个简单的文档格式修复，确保项目文档的标准化。