### PR TITLE
refactor(auth): simplify user response to only include id

### DIFF
--- a/src/cli/commands/logout.ts
+++ b/src/cli/commands/logout.ts
@@ -32,15 +32,10 @@ async function logoutAction(options: LogoutOptions): Promise<void> {
     return;
   }
 
-  const email = authManager.getEmail(registry);
-
   // Remove token
   authManager.removeToken(registry);
 
   logger.log('✓ Logged out successfully');
-  if (email) {
-    logger.log(`  Email: ${email}`);
-  }
   logger.log(`  Registry: ${registry}`);
 }
 
@@ -50,7 +45,10 @@ async function logoutAction(options: LogoutOptions): Promise<void> {
 
 export const logoutCommand = new Command('logout')
   .description('Log out from a reskill registry')
-  .option('-r, --registry <url>', 'Registry URL (or set RESKILL_REGISTRY env var, or defaults.publishRegistry in skills.json)')
+  .option(
+    '-r, --registry <url>',
+    'Registry URL (or set RESKILL_REGISTRY env var, or defaults.publishRegistry in skills.json)',
+  )
   .action(logoutAction);
 
 export default logoutCommand;

--- a/src/cli/commands/publish.ts
+++ b/src/cli/commands/publish.ts
@@ -10,16 +10,21 @@ import * as path from 'node:path';
 import { createInterface } from 'node:readline';
 import { Command } from 'commander';
 import { AuthManager } from '../../core/auth-manager.js';
-import { Publisher, PublishError, type GitInfo, type PublishPayload } from '../../core/publisher.js';
+import {
+  type GitInfo,
+  PublishError,
+  Publisher,
+  type PublishPayload,
+} from '../../core/publisher.js';
 import { RegistryClient, RegistryError } from '../../core/registry-client.js';
 import {
-  SkillValidator,
   type LoadedSkill,
+  SkillValidator,
   type ValidationResult,
 } from '../../core/skill-validator.js';
 import { logger } from '../../utils/logger.js';
 import { resolveRegistry } from '../../utils/registry.js';
-import { getScopeForRegistry, buildFullSkillName } from '../../utils/registry-scope.js';
+import { buildFullSkillName, getScopeForRegistry } from '../../utils/registry-scope.js';
 
 // ============================================================================
 // Types
@@ -67,11 +72,7 @@ const BLOCKED_PUBLIC_REGISTRIES = [
  *
  * @internal Exported for testing
  */
-export function buildPublishSkillName(
-  name: string,
-  registry: string,
-  userHandle: string,
-): string {
+export function buildPublishSkillName(name: string, registry: string, userHandle: string): string {
   // If name already has scope, use as-is
   if (name.includes('/')) {
     return name;
@@ -96,13 +97,13 @@ export function isBlockedPublicRegistry(registryUrl: string): boolean {
   try {
     const url = new URL(registryUrl);
     const hostname = url.hostname.toLowerCase();
-    return BLOCKED_PUBLIC_REGISTRIES.some(blocked => 
-      hostname === blocked || hostname.endsWith(`.${blocked}`)
+    return BLOCKED_PUBLIC_REGISTRIES.some(
+      (blocked) => hostname === blocked || hostname.endsWith(`.${blocked}`),
     );
   } catch {
     // If URL parsing fails, check if the string contains blocked domains
     const lowerUrl = registryUrl.toLowerCase();
-    return BLOCKED_PUBLIC_REGISTRIES.some(blocked => lowerUrl.includes(blocked));
+    return BLOCKED_PUBLIC_REGISTRIES.some((blocked) => lowerUrl.includes(blocked));
   }
 }
 
@@ -139,7 +140,7 @@ function checkAuth(registry: string, dryRun: boolean): { token: string } | null 
     }
     logger.error('Authentication required');
     logger.newline();
-    logger.log("You must be logged in to publish skills.");
+    logger.log('You must be logged in to publish skills.');
     logger.log("Run 'reskill login' to authenticate.");
     process.exit(1);
   }
@@ -150,10 +151,7 @@ function checkAuth(registry: string, dryRun: boolean): { token: string } | null 
 /**
  * Display validation results
  */
-function displayValidation(
-  skill: LoadedSkill,
-  validation: ValidationResult,
-): void {
+function displayValidation(skill: LoadedSkill, validation: ValidationResult): void {
   logger.log('Validating skill...');
 
   // SKILL.md is the primary file per agentskills.io spec
@@ -317,24 +315,17 @@ function displayWarnings(validation: ValidationResult): void {
 /**
  * Confirm publish
  */
-async function confirmPublish(
-  name: string,
-  version: string,
-  registry: string,
-): Promise<boolean> {
+async function confirmPublish(name: string, version: string, registry: string): Promise<boolean> {
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout,
   });
 
   return new Promise((resolve) => {
-    rl.question(
-      `\n? Publish ${name}@${version} to ${registry}? (y/N) `,
-      (answer) => {
-        rl.close();
-        resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
-      },
-    );
+    rl.question(`\n? Publish ${name}@${version} to ${registry}? (y/N) `, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+    });
   });
 }
 
@@ -352,10 +343,7 @@ function displayDryRunSummary(payload: PublishPayload): void {
 // Main Action
 // ============================================================================
 
-async function publishAction(
-  skillPath: string,
-  options: PublishOptions,
-): Promise<void> {
+async function publishAction(skillPath: string, options: PublishOptions): Promise<void> {
   const absolutePath = path.resolve(skillPath);
   const registry = resolveRegistry(options.registry, absolutePath);
 
@@ -416,9 +404,13 @@ async function publishAction(
     // 7. Display preview
     logger.newline();
     if (options.dryRun) {
-      logger.log(`📦 Dry run: ${skill.skillJson?.name || 'unknown'}@${skill.skillJson?.version || 'unknown'}`);
+      logger.log(
+        `📦 Dry run: ${skill.skillJson?.name || 'unknown'}@${skill.skillJson?.version || 'unknown'}`,
+      );
     } else {
-      logger.log(`📦 Publishing ${skill.skillJson?.name || 'unknown'}@${skill.skillJson?.version || 'unknown'}...`);
+      logger.log(
+        `📦 Publishing ${skill.skillJson?.name || 'unknown'}@${skill.skillJson?.version || 'unknown'}...`,
+      );
     }
     logger.newline();
 
@@ -467,7 +459,7 @@ async function publishAction(
     if (!token) {
       logger.error('Authentication required');
       logger.newline();
-      logger.log("You must be logged in to publish skills.");
+      logger.log('You must be logged in to publish skills.');
       logger.log("Run 'reskill login' to authenticate.");
       process.exit(1);
     }
@@ -480,17 +472,11 @@ async function publishAction(
 
     try {
       // Get skill name with scope
-      // Priority: registry scope > user handle
-      const handle = authManager.getHandle(registry) || 'unknown';
+      // Priority: registry scope > 'unknown' (fallback)
       const name = skill.skillJson?.name ?? '';
-      const skillName = buildPublishSkillName(name, registry, handle);
+      const skillName = buildPublishSkillName(name, registry, 'unknown');
 
-      const result = await client.publish(
-        skillName,
-        payload!,
-        absolutePath,
-        { tag: options.tag },
-      );
+      const result = await client.publish(skillName, payload!, absolutePath, { tag: options.tag });
 
       if (!result.success || !result.data) {
         logger.error(result.error || 'Publish failed');
@@ -506,7 +492,6 @@ async function publishAction(
       logger.log(`  Integrity: ${result.data.integrity}`);
       logger.newline();
       logger.log(`View at: ${registry}/skills/${encodeURIComponent(result.data.name)}`);
-
     } catch (publishError) {
       if (publishError instanceof RegistryError) {
         logger.error(`Publish failed: ${publishError.message}`);
@@ -520,7 +505,6 @@ async function publishAction(
       }
       process.exit(1);
     }
-
   } catch (error) {
     if (error instanceof PublishError) {
       logger.error(error.message);
@@ -538,7 +522,10 @@ export const publishCommand = new Command('publish')
   .alias('pub')
   .description('Publish a skill to the registry')
   .argument('[path]', 'Path to skill directory', '.')
-  .option('-r, --registry <url>', 'Registry URL (or set RESKILL_REGISTRY env var, or defaults.publishRegistry in skills.json)')
+  .option(
+    '-r, --registry <url>',
+    'Registry URL (or set RESKILL_REGISTRY env var, or defaults.publishRegistry in skills.json)',
+  )
   .option('-t, --tag <tag>', 'Git tag to publish')
   .option('--access <level>', 'Access level: public or restricted', 'public')
   .option('-n, --dry-run', 'Validate without publishing')

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -41,18 +41,15 @@ async function whoamiAction(options: WhoamiOptions): Promise<void> {
   try {
     const response = await client.whoami();
 
-    if (!response.success || !response.publisher) {
+    if (!response.success || !response.user) {
       logger.error('Failed to get user info');
       process.exit(1);
     }
 
-    const { publisher } = response;
+    const { user } = response;
 
-    logger.log(`@${publisher.handle}`);
-    logger.log(`  Email: ${publisher.email}`);
-    logger.log(`  Verified: ${publisher.email_verified ? 'Yes' : 'No'}`);
+    logger.log(`Logged in as: ${user.id}`);
     logger.log(`  Registry: ${registry}`);
-
   } catch (error) {
     if (error instanceof RegistryError) {
       if (error.statusCode === 401) {
@@ -75,7 +72,10 @@ async function whoamiAction(options: WhoamiOptions): Promise<void> {
 
 export const whoamiCommand = new Command('whoami')
   .description('Show current authenticated user')
-  .option('-r, --registry <url>', 'Registry URL (or set RESKILL_REGISTRY env var, or defaults.publishRegistry in skills.json)')
+  .option(
+    '-r, --registry <url>',
+    'Registry URL (or set RESKILL_REGISTRY env var, or defaults.publishRegistry in skills.json)',
+  )
   .action(whoamiAction);
 
 export default whoamiCommand;

--- a/src/core/auth-manager.test.ts
+++ b/src/core/auth-manager.test.ts
@@ -235,7 +235,6 @@ describe('AuthManager', () => {
         registries: {
           'https://existing.registry.com': {
             token: 'existing_token',
-            email: 'user@example.com',
           },
         },
       });
@@ -263,17 +262,6 @@ describe('AuthManager', () => {
 
       const config = readReskillrc() as { registries: Record<string, { token: string }> };
       expect(config.registries[testRegistry].token).toBe('new_token');
-    });
-
-    it('should save email if provided', () => {
-      const testRegistry = 'https://test.registry.com';
-      const manager = new AuthManager();
-      manager.setToken('token', testRegistry, 'user@example.com');
-
-      const config = readReskillrc() as {
-        registries: Record<string, { token: string; email?: string }>;
-      };
-      expect(config.registries[testRegistry].email).toBe('user@example.com');
     });
   });
 
@@ -422,59 +410,6 @@ describe('AuthManager', () => {
     it('should return path to ~/.reskillrc', () => {
       const manager = new AuthManager();
       expect(manager.getConfigPath()).toBe(path.join(tempDir, '.reskillrc'));
-    });
-  });
-
-  // ============================================================================
-  // getEmail tests
-  // ============================================================================
-
-  describe('getEmail', () => {
-    it('should return email from config for specific registry', () => {
-      const testRegistry = 'https://test.registry.com';
-      createReskillrc({
-        registries: {
-          [testRegistry]: {
-            token: 'token',
-            email: 'user@example.com',
-          },
-        },
-      });
-
-      const manager = new AuthManager();
-      expect(manager.getEmail(testRegistry)).toBe('user@example.com');
-    });
-
-    it('should return undefined when no email', () => {
-      const testRegistry = 'https://test.registry.com';
-      createReskillrc({
-        registries: {
-          [testRegistry]: {
-            token: 'token',
-          },
-        },
-      });
-
-      const manager = new AuthManager();
-      expect(manager.getEmail(testRegistry)).toBeUndefined();
-    });
-
-    it('should return email for specific registry from multiple', () => {
-      createReskillrc({
-        registries: {
-          'https://primary.registry.com': {
-            token: 'token1',
-            email: 'primary@example.com',
-          },
-          'https://custom.registry.com': {
-            token: 'token2',
-            email: 'custom@example.com',
-          },
-        },
-      });
-
-      const manager = new AuthManager();
-      expect(manager.getEmail('https://custom.registry.com')).toBe('custom@example.com');
     });
   });
 });

--- a/src/core/auth-manager.ts
+++ b/src/core/auth-manager.ts
@@ -14,8 +14,6 @@ import * as path from 'node:path';
 
 export interface RegistryAuth {
   token: string;
-  email?: string;
-  handle?: string;
 }
 
 export interface ReskillConfig {
@@ -93,52 +91,20 @@ export class AuthManager {
   }
 
   /**
-   * Get email for a registry
-   */
-  getEmail(registry?: string): string | undefined {
-    const config = this.readConfig();
-    if (!config?.registries) {
-      return undefined;
-    }
-
-    const targetRegistry = registry || this.getDefaultRegistry();
-    if (!targetRegistry) {
-      return undefined;
-    }
-    const auth = config.registries[targetRegistry];
-    return auth?.email;
-  }
-
-  /**
-   * Get handle for a registry
-   */
-  getHandle(registry?: string): string | undefined {
-    const config = this.readConfig();
-    if (!config?.registries) {
-      return undefined;
-    }
-
-    const targetRegistry = registry || this.getDefaultRegistry();
-    if (!targetRegistry) {
-      return undefined;
-    }
-    const auth = config.registries[targetRegistry];
-    return auth?.handle;
-  }
-
-  /**
    * Set token for a registry
    *
    * Note: When no registry is specified and RESKILL_REGISTRY env var is not set,
    * this method will throw an error. The calling code should ensure a registry
    * is always provided (either explicitly or via environment variable).
    */
-  setToken(token: string, registry?: string, email?: string, handle?: string): void {
+  setToken(token: string, registry?: string): void {
     const config = this.readConfig() || {};
     const targetRegistry = registry || this.getDefaultRegistry();
 
     if (!targetRegistry) {
-      throw new Error('No registry specified. Set RESKILL_REGISTRY environment variable or provide registry explicitly.');
+      throw new Error(
+        'No registry specified. Set RESKILL_REGISTRY environment variable or provide registry explicitly.',
+      );
     }
 
     if (!config.registries) {
@@ -147,8 +113,6 @@ export class AuthManager {
 
     config.registries[targetRegistry] = {
       token,
-      ...(email && { email }),
-      ...(handle && { handle }),
     };
 
     this.writeConfig(config);

--- a/src/core/registry-client.ts
+++ b/src/core/registry-client.ts
@@ -27,12 +27,8 @@ export interface LoginRequest {
 export interface LoginResponse {
   success: boolean;
   error?: string;
-  publisher?: {
+  user?: {
     id: string;
-    handle: string;
-    email: string;
-    email_verified: boolean;
-    created_at: string;
   };
   token?: {
     id: string;
@@ -68,12 +64,8 @@ export interface PublishResponse {
 export interface WhoamiResponse {
   success: boolean;
   error?: string;
-  publisher?: {
+  user?: {
     id: string;
-    handle: string;
-    email: string;
-    email_verified: boolean;
-    created_at: string;
   };
 }
 
@@ -131,7 +123,7 @@ export class RegistryClient {
       body: JSON.stringify(request),
     });
 
-    const data = await response.json() as LoginResponse;
+    const data = (await response.json()) as LoginResponse;
 
     if (!response.ok) {
       throw new RegistryError(
@@ -155,7 +147,7 @@ export class RegistryClient {
       headers: this.getAuthHeaders(),
     });
 
-    const data = await response.json() as WhoamiResponse;
+    const data = (await response.json()) as WhoamiResponse;
 
     if (!response.ok) {
       throw new RegistryError(
@@ -266,7 +258,7 @@ export class RegistryClient {
       body: formData,
     });
 
-    const data = await response.json() as PublishResponse;
+    const data = (await response.json()) as PublishResponse;
 
     if (!response.ok) {
       throw new RegistryError(


### PR DESCRIPTION
- Change WhoamiResponse and LoginResponse to use 'user.id' instead of 'publisher' with multiple fields
- Remove email, handle, email_verified, created_at from API response types
- Remove getEmail() and getHandle() methods from AuthManager
- Simplify setToken() to only store token (no email/handle)
- Update login, logout, whoami commands to use new simplified response
- Update publish command to use 'unknown' as fallback scope
- Remove related tests for removed functionality

精简登录认证功能，把之前返回的邮箱、用户名等一堆用户信息，改成只返回一个用户 ID