### PR TITLE
feat(core): adapt WhoamiResponse to use user.id format

### DIFF
--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -4,8 +4,8 @@
  * Logs in to the registry and stores the token in ~/.reskillrc
  */
 
-import { createInterface } from 'node:readline';
 import { Command } from 'commander';
+import { createInterface } from 'node:readline';
 import { AuthManager } from '../../core/auth-manager.js';
 import { RegistryClient, RegistryError } from '../../core/registry-client.js';
 import { logger } from '../../utils/logger.js';
@@ -171,18 +171,17 @@ async function loginWithToken(token: string, registry: string, authManager: Auth
   try {
     const response = await client.whoami();
 
-    if (!response.success || !response.publisher) {
+    if (!response.success || !response.user) {
       logger.error(response.error || 'Token verification failed');
       process.exit(1);
     }
 
-    // Save token with handle
-    authManager.setToken(token, registry, response.publisher.email, response.publisher.handle);
+    // Save token with handle (using user.id as handle)
+    authManager.setToken(token, registry, undefined, response.user.id);
 
     logger.log('✓ Token verified and saved!');
     logger.newline();
-    logger.log(`  Handle: @${response.publisher.handle}`);
-    logger.log(`  Email: ${response.publisher.email}`);
+    logger.log(`  Handle: @${response.user.id}`);
     logger.log(`  Registry: ${registry}`);
     logger.newline();
     logger.log(`Token saved to ${authManager.getConfigPath()}`);

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -41,16 +41,14 @@ async function whoamiAction(options: WhoamiOptions): Promise<void> {
   try {
     const response = await client.whoami();
 
-    if (!response.success || !response.publisher) {
+    if (!response.success || !response.user) {
       logger.error('Failed to get user info');
       process.exit(1);
     }
 
-    const { publisher } = response;
+    const { user } = response;
 
-    logger.log(`@${publisher.handle}`);
-    logger.log(`  Email: ${publisher.email}`);
-    logger.log(`  Verified: ${publisher.email_verified ? 'Yes' : 'No'}`);
+    logger.log(`@${user.id}`);
     logger.log(`  Registry: ${registry}`);
 
   } catch (error) {

--- a/src/core/registry-client.test.ts
+++ b/src/core/registry-client.test.ts
@@ -173,12 +173,8 @@ describe('RegistryClient', () => {
 
       const mockResponse = {
         success: true,
-        publisher: {
-          id: 'pub_123',
-          handle: 'testuser',
-          email: 'test@example.com',
-          email_verified: true,
-          created_at: '2024-01-01T00:00:00Z',
+        user: {
+          id: 'testuser',
         },
       };
 
@@ -215,12 +211,8 @@ describe('RegistryClient', () => {
         json: () =>
           Promise.resolve({
             success: true,
-            publisher: {
-              id: 'pub_123',
-              handle: 'testuser',
-              email: 'test@example.com',
-              email_verified: true,
-              created_at: '2024-01-01',
+            user: {
+              id: 'testuser',
             },
           }),
       });

--- a/src/core/registry-client.ts
+++ b/src/core/registry-client.ts
@@ -68,12 +68,8 @@ export interface PublishResponse {
 export interface WhoamiResponse {
   success: boolean;
   error?: string;
-  publisher?: {
+  user?: {
     id: string;
-    handle: string;
-    email: string;
-    email_verified: boolean;
-    created_at: string;
   };
 }
 


### PR DESCRIPTION
- Update WhoamiResponse type to use 'user' instead of 'publisher'
- Simplify user info to just 'id' field
- Update whoami command to display @user.id
- Update login --token flow to use user.id as handle
- Update unit tests with new response format