### PR TITLE
feat(auth): token-only login, remove email/password support

### DIFF
--- a/src/cli/commands/login.test.ts
+++ b/src/cli/commands/login.test.ts
@@ -31,15 +31,15 @@ describe('login command', () => {
       expect(registryOption?.description).toContain('Registry URL');
     });
 
-    it('should have --token option for pre-generated tokens', () => {
+    it('should have --token option for API token', () => {
       const tokenOption = loginCommand.options.find(
         (opt) => opt.short === '-t' || opt.long === '--token',
       );
       expect(tokenOption).toBeDefined();
       expect(tokenOption?.flags).toContain('-t');
       expect(tokenOption?.flags).toContain('--token');
-      expect(tokenOption?.description).toContain('pre-generated token');
-      expect(tokenOption?.description).toContain('CAS');
+      expect(tokenOption?.description).toContain('token');
+      expect(tokenOption?.description).toContain('Web UI');
     });
 
     it('registry option should accept a URL argument', () => {
@@ -91,12 +91,29 @@ describe('login command', () => {
       expect(registryOption?.description).toContain('RESKILL_REGISTRY');
     });
 
-    it('token option description should mention OAuth/CAS', () => {
+    it('token option description should mention Web UI', () => {
       const tokenOption = loginCommand.options.find(
         (opt) => opt.long === '--token',
       );
-      // Description mentions CAS/OAuth use case
-      expect(tokenOption?.description).toContain('OAuth');
+      // Token-only login: description should mention Web UI
+      expect(tokenOption?.description).toContain('Web UI');
+    });
+  });
+
+  // ============================================================================
+  // Token-only login tests (email/password removed)
+  // ============================================================================
+
+  describe('token-only login', () => {
+    it('token option should indicate it is required', () => {
+      // After removing email/password login, token should be the only way to login
+      // The --token option description should indicate it's required
+      const tokenOption = loginCommand.options.find(
+        (opt) => opt.long === '--token',
+      );
+      expect(tokenOption).toBeDefined();
+      // Description should indicate it's required
+      expect(tokenOption?.description?.toLowerCase()).toContain('required');
     });
   });
 });

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -1,11 +1,11 @@
 /**
  * login command - Authenticate with a reskill registry
  *
+ * Token-only login: requires a pre-generated token from Web UI.
  * Logs in to the registry and stores the token in ~/.reskillrc
  */
 
 import { Command } from 'commander';
-import { createInterface } from 'node:readline';
 import { AuthManager } from '../../core/auth-manager.js';
 import { RegistryClient, RegistryError } from '../../core/registry-client.js';
 import { logger } from '../../utils/logger.js';
@@ -21,59 +21,6 @@ interface LoginOptions {
 }
 
 // ============================================================================
-// Helper Functions
-// ============================================================================
-
-/**
- * Prompt for input (with optional masking for passwords)
- */
-function prompt(question: string, hidden = false): Promise<string> {
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  return new Promise((resolve) => {
-    if (hidden && process.stdin.isTTY) {
-      // Hide password input
-      process.stdout.write(question);
-      let input = '';
-
-      process.stdin.setRawMode(true);
-      process.stdin.resume();
-      process.stdin.setEncoding('utf8');
-
-      const onData = (char: string) => {
-        if (char === '\n' || char === '\r') {
-          process.stdin.setRawMode(false);
-          process.stdin.removeListener('data', onData);
-          process.stdout.write('\n');
-          rl.close();
-          resolve(input);
-        } else if (char === '\u0003') {
-          // Ctrl+C
-          process.exit(0);
-        } else if (char === '\u007F' || char === '\b') {
-          // Backspace
-          if (input.length > 0) {
-            input = input.slice(0, -1);
-          }
-        } else {
-          input += char;
-        }
-      };
-
-      process.stdin.on('data', onData);
-    } else {
-      rl.question(question, (answer) => {
-        rl.close();
-        resolve(answer);
-      });
-    }
-  });
-}
-
-// ============================================================================
 // Main Action
 // ============================================================================
 
@@ -81,87 +28,28 @@ async function loginAction(options: LoginOptions): Promise<void> {
   const registry = resolveRegistry(options.registry);
   const authManager = new AuthManager();
 
-  // If token is provided directly, save it and verify
-  if (options.token) {
-    await loginWithToken(options.token, registry, authManager);
-    return;
-  }
-
-  // Check if already logged in
-  const existingToken = authManager.getToken(registry);
-  if (existingToken) {
-    const existingEmail = authManager.getEmail(registry);
-    logger.log(`Already logged in to ${registry}`);
-    if (existingEmail) {
-      logger.log(`  Email: ${existingEmail}`);
-    }
+  // Token is required (no email/password login)
+  if (!options.token) {
+    logger.error('Token is required');
     logger.newline();
-
-    const overwrite = await prompt('Do you want to login with a different account? (y/N) ');
-    if (overwrite.toLowerCase() !== 'y' && overwrite.toLowerCase() !== 'yes') {
-      logger.log('Cancelled.');
-      return;
-    }
-    logger.newline();
-  }
-
-  logger.log(`Logging in to ${registry}...`);
-  logger.newline();
-
-  // Prompt for credentials
-  const email = await prompt('Email: ');
-  if (!email.trim()) {
-    logger.error('Email is required');
+    logger.log('To get a token:');
+    logger.log('  1. Visit the Registry Web UI');
+    logger.log('  2. Login and generate an API token');
+    logger.log('  3. Run: reskill login --registry <url> --token <token>');
     process.exit(1);
   }
 
-  const password = await prompt('Password: ', true);
-  if (!password) {
-    logger.error('Password is required');
-    process.exit(1);
-  }
-
-  logger.newline();
-
-  // Login
-  const client = new RegistryClient({ registry });
-
-  try {
-    const response = await client.login({ email: email.trim(), password });
-
-    if (!response.success || !response.token || !response.publisher) {
-      logger.error(response.error || 'Login failed');
-      process.exit(1);
-    }
-
-    // Save token with handle
-    authManager.setToken(response.token.secret, registry, response.publisher.email, response.publisher.handle);
-
-    logger.log('✓ Logged in successfully!');
-    logger.newline();
-    logger.log(`  Handle: @${response.publisher.handle}`);
-    logger.log(`  Email: ${response.publisher.email}`);
-    logger.log(`  Registry: ${registry}`);
-    logger.newline();
-    logger.log(`Token saved to ${authManager.getConfigPath()}`);
-
-  } catch (error) {
-    if (error instanceof RegistryError) {
-      logger.error(`Login failed: ${error.message}`);
-      if (error.statusCode === 401) {
-        logger.log('Please check your email and password.');
-      }
-    } else {
-      logger.error(`Login failed: ${(error as Error).message}`);
-    }
-    process.exit(1);
-  }
+  await loginWithToken(options.token, registry, authManager);
 }
 
 /**
- * Login with a pre-generated token (e.g., from web UI after CAS/OAuth login)
+ * Login with a pre-generated token from Web UI
  */
-async function loginWithToken(token: string, registry: string, authManager: AuthManager): Promise<void> {
+async function loginWithToken(
+  token: string,
+  registry: string,
+  authManager: AuthManager,
+): Promise<void> {
   logger.log(`Verifying token with ${registry}...`);
   logger.newline();
 
@@ -176,21 +64,21 @@ async function loginWithToken(token: string, registry: string, authManager: Auth
       process.exit(1);
     }
 
-    // Save token with handle (using user.id as handle)
-    authManager.setToken(token, registry, undefined, response.user.id);
+    // Save token with handle (use user.handle, not user.id)
+    authManager.setToken(token, registry, undefined, response.user.handle);
 
     logger.log('✓ Token verified and saved!');
     logger.newline();
-    logger.log(`  Handle: @${response.user.id}`);
+    logger.log(`  Handle: @${response.user.handle}`);
+    logger.log(`  Username: ${response.user.id}`);
     logger.log(`  Registry: ${registry}`);
     logger.newline();
     logger.log(`Token saved to ${authManager.getConfigPath()}`);
-
   } catch (error) {
     if (error instanceof RegistryError) {
       logger.error(`Token verification failed: ${error.message}`);
       if (error.statusCode === 401) {
-        logger.log('The token is invalid or expired. Please generate a new token from the web UI.');
+        logger.log('The token is invalid or expired. Please generate a new token from the Web UI.');
       }
     } else {
       logger.error(`Token verification failed: ${(error as Error).message}`);
@@ -205,8 +93,11 @@ async function loginWithToken(token: string, registry: string, authManager: Auth
 
 export const loginCommand = new Command('login')
   .description('Authenticate with a reskill registry')
-  .option('-r, --registry <url>', 'Registry URL (or set RESKILL_REGISTRY env var, or defaults.publishRegistry in skills.json)')
-  .option('-t, --token <token>', 'Use a pre-generated token (from web UI after CAS/OAuth login)')
+  .option(
+    '-r, --registry <url>',
+    'Registry URL (or set RESKILL_REGISTRY env var, or defaults.publishRegistry in skills.json)',
+  )
+  .option('-t, --token <token>', 'API token from Web UI (required)')
   .action(loginAction);
 
 export default loginCommand;

--- a/src/cli/commands/publish.test.ts
+++ b/src/cli/commands/publish.test.ts
@@ -129,14 +129,13 @@ describe('publish command', () => {
     });
 
     describe('with unknown registry scope', () => {
-      it('should fallback to user handle for unknown registry', () => {
-        const result = buildPublishSkillName(
+      it('should throw error for unknown registry (no fallback)', () => {
+        // Registry must be in REGISTRY_SCOPE_MAP, no fallback to userHandle
+        expect(() => buildPublishSkillName(
           'my-skill',
           'https://unknown-registry.com/',
           'wangzirenbj',
-        );
-        // Falls back to user handle when registry scope is not configured
-        expect(result).toBe('@wangzirenbj/my-skill');
+        )).toThrow('No scope configured for registry');
       });
     });
 

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -48,9 +48,9 @@ async function whoamiAction(options: WhoamiOptions): Promise<void> {
 
     const { user } = response;
 
-    logger.log(`@${user.id}`);
+    logger.log(`@${user.handle}`);
+    logger.log(`  Username: ${user.id}`);
     logger.log(`  Registry: ${registry}`);
-
   } catch (error) {
     if (error instanceof RegistryError) {
       if (error.statusCode === 401) {
@@ -73,7 +73,10 @@ async function whoamiAction(options: WhoamiOptions): Promise<void> {
 
 export const whoamiCommand = new Command('whoami')
   .description('Show current authenticated user')
-  .option('-r, --registry <url>', 'Registry URL (or set RESKILL_REGISTRY env var, or defaults.publishRegistry in skills.json)')
+  .option(
+    '-r, --registry <url>',
+    'Registry URL (or set RESKILL_REGISTRY env var, or defaults.publishRegistry in skills.json)',
+  )
   .action(whoamiAction);
 
 export default whoamiCommand;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,9 +8,9 @@ export {
   getAllAgentTypes,
   isValidAgentType,
 } from './agent-registry.js';
+export type { RegistryAuth, ReskillConfig } from './auth-manager.js';
 // Auth management
 export { AuthManager } from './auth-manager.js';
-export type { RegistryAuth, ReskillConfig } from './auth-manager.js';
 export { CacheManager } from './cache-manager.js';
 export { ConfigLoader, DEFAULT_REGISTRIES } from './config-loader.js';
 /**
@@ -24,6 +24,17 @@ export { HttpResolver } from './http-resolver.js';
 export type { InstallerOptions, InstallMode, InstallResult } from './installer.js';
 export { Installer } from './installer.js';
 export { LockManager } from './lock-manager.js';
+// Publisher
+export type { GitInfo, PublishPayload } from './publisher.js';
+export { PublishError, Publisher } from './publisher.js';
+// Registry client
+export type {
+  PublishRequest,
+  PublishResponse,
+  RegistryConfig,
+  WhoamiResponse,
+} from './registry-client.js';
+export { RegistryClient, RegistryError } from './registry-client.js';
 export type { SkillManagerOptions } from './skill-manager.js';
 export { SkillManager } from './skill-manager.js';
 export type { ParsedSkill, SkillMdFrontmatter } from './skill-parser.js';
@@ -37,19 +48,11 @@ export {
   validateSkillDescription,
   validateSkillName,
 } from './skill-parser.js';
-// Publisher
-export type { GitInfo, PublishPayload } from './publisher.js';
-export { Publisher, PublishError } from './publisher.js';
-// Registry client
-export type {
-  LoginRequest,
-  LoginResponse,
-  PublishRequest,
-  PublishResponse,
-  RegistryConfig,
-  WhoamiResponse,
-} from './registry-client.js';
-export { RegistryClient, RegistryError } from './registry-client.js';
 // Skill validator
-export type { LoadedSkill, ValidationError, ValidationResult, ValidationWarning } from './skill-validator.js';
+export type {
+  LoadedSkill,
+  ValidationError,
+  ValidationResult,
+  ValidationWarning,
+} from './skill-validator.js';
 export { SkillValidator } from './skill-validator.js';


### PR DESCRIPTION
- Remove LoginRequest, LoginResponse types and login() method from registry-client
- Simplify login command to require --token flag (no email/password prompt)
- Add handle field to WhoamiResponse type
- Update loginWithToken() to use user.handle instead of user.id
- Update whoami command to display @handle and username
- Update buildPublishSkillName() to throw error when registry not in scope map
- Remove fallback to userHandle in publish
- Update tests to reflect new token-only authentication

BREAKING CHANGE: reskill login now requires --token flag. Email/password login is no longer supported.