### PR TITLE
fix(cache): include subPath in cache path for monorepo skills

### DIFF
--- a/.changeset/fix-monorepo-cache-collision.md
+++ b/.changeset/fix-monorepo-cache-collision.md
@@ -1,0 +1,31 @@
+---
+"reskill": patch
+---
+
+Fix cache collision for different skills in the same monorepo
+
+**Bug:**
+When installing multiple skills from the same monorepo (e.g., `github:antfu/skills/skills/unocss` and `github:antfu/skills/skills/pnpm`), they would share the same cache path, causing the wrong skill to be installed.
+
+**Root Cause:**
+The `getSkillCachePath` method did not include the `subPath` in the cache path calculation, resulting in all skills from the same repo using identical cache paths.
+
+**Fix:**
+Include `subPath` in the cache path to ensure each skill has its own unique cache location:
+- Before: `~/.reskill-cache/github/antfu/skills/main/`
+- After: `~/.reskill-cache/github/antfu/skills/skills/unocss/main/`
+
+---
+
+修复同一 monorepo 中不同 skills 的缓存冲突问题
+
+**Bug:**
+从同一个 monorepo 安装多个 skills 时（如 `github:antfu/skills/skills/unocss` 和 `github:antfu/skills/skills/pnpm`），它们会共用同一个缓存路径，导致安装错误的 skill。
+
+**根本原因:**
+`getSkillCachePath` 方法在计算缓存路径时没有包含 `subPath`，导致同一仓库的所有 skills 使用相同的缓存路径。
+
+**修复:**
+在缓存路径中包含 `subPath`，确保每个 skill 有独立的缓存位置：
+- 修复前: `~/.reskill-cache/github/antfu/skills/main/`
+- 修复后: `~/.reskill-cache/github/antfu/skills/skills/unocss/main/`

--- a/src/core/cache-manager.test.ts
+++ b/src/core/cache-manager.test.ts
@@ -50,6 +50,44 @@ describe('CacheManager', () => {
         path.join(tempDir, 'gitlab.company.com', 'team', 'my-skill', 'v2.0.0'),
       );
     });
+
+    it('should include subPath in cache path for monorepo skills', () => {
+      const parsedWithSubpath: ParsedSkillRef = {
+        registry: 'github',
+        owner: 'antfu',
+        repo: 'skills',
+        subPath: 'skills/unocss',
+        raw: 'github:antfu/skills/skills/unocss@v1.0.0',
+      };
+      const cachePath = cacheManager.getSkillCachePath(parsedWithSubpath, 'v1.0.0');
+      expect(cachePath).toBe(
+        path.join(tempDir, 'github', 'antfu', 'skills', 'skills', 'unocss', 'v1.0.0'),
+      );
+    });
+
+    it('should differentiate cache paths for different skills in same monorepo', () => {
+      const parsedUnocss: ParsedSkillRef = {
+        registry: 'github',
+        owner: 'antfu',
+        repo: 'skills',
+        subPath: 'skills/unocss',
+        raw: 'github:antfu/skills/skills/unocss@main',
+      };
+      const parsedPnpm: ParsedSkillRef = {
+        registry: 'github',
+        owner: 'antfu',
+        repo: 'skills',
+        subPath: 'skills/pnpm',
+        raw: 'github:antfu/skills/skills/pnpm@main',
+      };
+      const unocssPath = cacheManager.getSkillCachePath(parsedUnocss, 'main');
+      const pnpmPath = cacheManager.getSkillCachePath(parsedPnpm, 'main');
+
+      // Cache paths must be different for different skills
+      expect(unocssPath).not.toBe(pnpmPath);
+      expect(unocssPath).toContain('unocss');
+      expect(pnpmPath).toContain('pnpm');
+    });
   });
 
   describe('isCached', () => {

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -56,11 +56,17 @@ export class CacheManager {
    *
    * For different reference formats, cache paths are:
    * - github:user/repo@v1.0.0 -> ~/.reskill-cache/github/user/repo/v1.0.0
+   * - github:org/monorepo/skills/pdf@v1.0.0 -> ~/.reskill-cache/github/org/monorepo/skills/pdf/v1.0.0
    * - git@github.com:user/repo.git@v1.0.0 -> ~/.reskill-cache/github.com/user/repo/v1.0.0
    * - https://gitlab.company.com/team/skill.git@v2.0.0 -> ~/.reskill-cache/gitlab.company.com/team/skill/v2.0.0
    */
   getSkillCachePath(parsed: ParsedSkillRef, version: string): string {
-    return path.join(this.cacheDir, parsed.registry, parsed.owner, parsed.repo, version);
+    const basePath = path.join(this.cacheDir, parsed.registry, parsed.owner, parsed.repo);
+    // Include subPath in cache path to differentiate skills in monorepos
+    if (parsed.subPath) {
+      return path.join(basePath, parsed.subPath, version);
+    }
+    return path.join(basePath, version);
   }
 
   /**


### PR DESCRIPTION
- Fix cache collision when installing different skills from same monorepo
- Add tests for monorepo cache path differentiation
- Before: all skills shared ~/.reskill-cache/github/org/repo/version/
- After: each skill has ~/.reskill-cache/github/org/repo/subpath/version/