### PR TITLE
feat(registry): support rush-app private registry with /api/reskill p…

### DIFF
--- a/.changeset/rush-app-migration.md
+++ b/.changeset/rush-app-migration.md
@@ -1,0 +1,31 @@
+---
+"reskill": minor
+---
+
+Support rush-app private registry with `/api/reskill` API prefix
+
+**Changes:**
+- Added `REGISTRY_API_PREFIX` mapping and `getApiPrefix()` to automatically resolve API path prefix per registry
+- Added `apiPrefix` option to `RegistryClient` with `getApiBase()` helper (handles trailing slash normalization)
+- Updated all `RegistryClient` instantiation sites to pass `apiPrefix`
+- Added 302/301 redirect handling in `downloadSkill()` to capture `x-integrity` header from registry before following redirect to OSS
+- Added `rush-test.zhenguanyu.com` (test) and `rush.zhenguanyu.com` (production) to scope mapping
+- Preserved backward compatibility with legacy `reskill-test.zhenguanyu.com` (uses default `/api` prefix)
+
+**Bug Fixes:**
+- Fixed potential double-slash in API URLs when registry URL has trailing slash
+
+---
+
+支持 rush-app 私域 Registry，使用 `/api/reskill` API 前缀
+
+**变更：**
+- 新增 `REGISTRY_API_PREFIX` 映射和 `getApiPrefix()` 函数，按域名自动选择 API 前缀
+- `RegistryClient` 新增 `apiPrefix` 配置项和 `getApiBase()` 方法（含尾斜杠归一化处理）
+- 所有 `RegistryClient` 实例化位置传入 `apiPrefix`
+- `downloadSkill()` 新增 302/301 重定向手动跟随，从 registry 的 302 响应中捕获 `x-integrity` 头后再从 OSS 下载 tarball
+- 新增 `rush-test.zhenguanyu.com`（测试）和 `rush.zhenguanyu.com`（生产）域名到 scope 映射
+- 保留旧域名 `reskill-test.zhenguanyu.com` 的向后兼容（使用默认 `/api` 前缀）
+
+**Bug 修复：**
+- 修复 registry URL 带尾斜杠时 API URL 产生双斜杠的问题

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -978,6 +978,22 @@ These options are available for all commands:
 
 ---
 
+## Registry API Prefix
+
+Different registries may host the reskill API under different path prefixes. The CLI automatically determines the correct API prefix based on the registry URL.
+
+| Registry | Domain | API Prefix | Example |
+|----------|--------|------------|---------|
+| Public | `reskill.info` | `/api` | `https://reskill.info/api/skills/...` |
+| Private (rush-app) | `rush-test.zhenguanyu.com` | `/api/reskill` | `https://rush-test.zhenguanyu.com/api/reskill/skills/...` |
+| Private (rush-app) | `rush.zhenguanyu.com` | `/api/reskill` | `https://rush.zhenguanyu.com/api/reskill/skills/...` |
+| Local dev | `localhost:3000` | `/api/reskill` | `http://localhost:3000/api/reskill/skills/...` |
+| Unknown | any other | `/api` (default) | `https://custom.com/api/skills/...` |
+
+The `getApiPrefix(registryUrl)` utility resolves the prefix. The `RegistryClient` accepts an optional `apiPrefix` in its config and uses it to construct all API endpoint URLs.
+
+---
+
 ## Environment Variables
 
 | Variable | Description |

--- a/docs/install-formats-summary.md
+++ b/docs/install-formats-summary.md
@@ -58,14 +58,14 @@
 
 从 Skill Registry 安装 skill。
 
-| 类型                     | 格式示例                            | Registry URL                           |
-| ------------------------ | ----------------------------------- | -------------------------------------- |
-| **私有 Registry**        | `@kanyun/planning-with-files`       | `https://reskill-test.zhenguanyu.com/` |
-| **私有 Registry + 版本** | `@kanyun/planning-with-files@2.4.5` | `https://reskill-test.zhenguanyu.com/` |
-| **私有 Registry + tag**  | `@kanyun/planning-with-files@beta`  | `https://reskill-test.zhenguanyu.com/` |
-| **公共 Registry**        | `planning-with-files`               | `https://reskill.info/`                |
-| **公共 Registry + 版本** | `planning-with-files@2.4.5`         | `https://reskill.info/`                |
-| **公共 Registry + tag**  | `planning-with-files@latest`        | `https://reskill.info/`                |
+| 类型                     | 格式示例                            | Registry URL                        |
+| ------------------------ | ----------------------------------- | ----------------------------------- |
+| **私有 Registry**        | `@kanyun/planning-with-files`       | `https://rush-test.zhenguanyu.com/` |
+| **私有 Registry + 版本** | `@kanyun/planning-with-files@2.4.5` | `https://rush-test.zhenguanyu.com/` |
+| **私有 Registry + tag**  | `@kanyun/planning-with-files@beta`  | `https://rush-test.zhenguanyu.com/` |
+| **公共 Registry**        | `planning-with-files`               | `https://reskill.info/`             |
+| **公共 Registry + 版本** | `planning-with-files@2.4.5`         | `https://reskill.info/`             |
+| **公共 Registry + tag**  | `planning-with-files@latest`        | `https://reskill.info/`             |
 
 ---
 
@@ -268,10 +268,10 @@ reskill install planning-with-files@latest
 
 ### 私有 Registry Scope 映射
 
-| Scope              | Registry URL                           |
-| ------------------ | -------------------------------------- |
-| `@kanyun`          | `https://reskill-test.zhenguanyu.com/` |
-| （localhost 开发） | `http://localhost:3000/`               |
+| Scope              | Registry URL                        |
+| ------------------ | ----------------------------------- |
+| `@kanyun`          | `https://rush-test.zhenguanyu.com/` |
+| （localhost 开发） | `http://localhost:3000/`            |
 
 ### 公共 Registry
 
@@ -285,8 +285,8 @@ reskill install planning-with-files@latest
 // src/utils/registry-scope.ts
 
 const REGISTRY_SCOPE_MAP: Record<string, string> = {
-  'https://reskill-test.zhenguanyu.com': '@kanyun',
-  'https://reskill-test.zhenguanyu.com/': '@kanyun',
+  'https://rush-test.zhenguanyu.com': '@kanyun',
+  'https://rush-test.zhenguanyu.com/': '@kanyun',
   'http://localhost:3000': '@kanyun',
   'http://localhost:3000/': '@kanyun',
 };

--- a/docs/private-registry-implementation-plan.md
+++ b/docs/private-registry-implementation-plan.md
@@ -80,7 +80,7 @@ Phase 5: 后续优化
 
 describe('getRegistryForScope', () => {
   it('should return registry for known scope', () => {
-    expect(getRegistryForScope('@kanyun')).toBe('https://reskill-test.zhenguanyu.com/');
+    expect(getRegistryForScope('@kanyun')).toBe('https://rush-test.zhenguanyu.com/');
   });
 
   it('should return registry for localhost scope', () => {
@@ -92,7 +92,7 @@ describe('getRegistryForScope', () => {
   });
 
   it('should handle scope without @ prefix', () => {
-    expect(getRegistryForScope('kanyun')).toBe('https://reskill-test.zhenguanyu.com/');
+    expect(getRegistryForScope('kanyun')).toBe('https://rush-test.zhenguanyu.com/');
   });
 });
 ```
@@ -398,7 +398,7 @@ describe('getRegistryUrl', () => {
   // 私有 Registry（有 scope）
   it('should resolve registry from known scope', () => {
     const registry = getRegistryUrl('@kanyun');
-    expect(registry).toBe('https://reskill-test.zhenguanyu.com/');
+    expect(registry).toBe('https://rush-test.zhenguanyu.com/');
   });
 
   it('should throw error for unknown scope', () => {
@@ -667,7 +667,7 @@ describe('extractTarball', () => {
 // src/e2e/publish-install.test.ts
 
 describe('E2E: publish and install from registry', () => {
-  const registry = 'https://reskill-test.zhenguanyu.com/';
+  const registry = 'https://rush-test.zhenguanyu.com/';
   
   beforeAll(async () => {
     // 启动测试 registry 服务或使用 mock

--- a/docs/private-registry-publish-install.md
+++ b/docs/private-registry-publish-install.md
@@ -77,7 +77,7 @@ AI 编码助手（如 Claude Code）期望的目录结构是：
  * 私域 Registry 配置
  */
 export const PRIVATE_REGISTRIES: Record<string, string> = {
-  'https://reskill-test.zhenguanyu.com/': '@kanyun',
+  'https://rush-test.zhenguanyu.com/': '@kanyun',
 };
 
 /**
@@ -129,7 +129,7 @@ reskill publish
 reskill publish ./planning-with-files
 
 # 发布到指定 registry
-reskill publish --registry=https://reskill-test.zhenguanyu.com/
+reskill publish --registry=https://rush-test.zhenguanyu.com/
 
 # 预览发布内容
 reskill publish --dry-run
@@ -140,7 +140,7 @@ reskill publish --dry-run
 ```
 输入：
     path: ./planning-with-files（或当前目录）
-    registry: https://reskill-test.zhenguanyu.com/
+    registry: https://rush-test.zhenguanyu.com/
     │
     ▼
 1. 确定 Skill 目录：
@@ -166,7 +166,7 @@ reskill publish --dry-run
     ├── 找到 → scope = @kanyun
     └── 未找到 → 报错 ❌
         "Only private registry publishing is supported.
-         Supported: https://reskill-test.zhenguanyu.com/"
+         Supported: https://rush-test.zhenguanyu.com/"
     │
     ▼
 5. 解析 Skill 信息：
@@ -252,7 +252,7 @@ reskill install @kanyun/planning-with-files@beta
 2. 确定 Registry：
     ├── --registry 参数
     ├── 或从 scope 反查 PRIVATE_REGISTRIES
-    │   @kanyun → https://reskill-test.zhenguanyu.com/
+    │   @kanyun → https://rush-test.zhenguanyu.com/
     └── 未找到 → 报错 ❌
         "Unknown scope @kanyun. Use --registry to specify."
     │
@@ -682,7 +682,7 @@ INSTALL:
 | -------------------------- | ------------------------------------------------------------------------------------------------ |
 | SKILL.md 不存在            | `SKILL.md not found in /path/to/dir`                                                             |
 | 未指定 Registry            | `No registry specified. Set RESKILL_REGISTRY or use --registry`                                  |
-| 非私域 Registry            | `Only private registry publishing is supported. Supported: https://reskill-test.zhenguanyu.com/` |
+| 非私域 Registry            | `Only private registry publishing is supported. Supported: https://rush-test.zhenguanyu.com/` |
 | 未知 Scope                 | `Unknown scope @xxx. Use --registry to specify.`                                                 |
 | 同名冲突                   | `Conflict: .claude/skills/xxx/ already exists.`                                                  |
 | Integrity 校验失败         | `Integrity check failed. Expected: sha256-xxx, Got: sha256-yyy`                                  |

--- a/scripts/test-download.ts
+++ b/scripts/test-download.ts
@@ -11,6 +11,7 @@
  */
 
 import { RegistryClient } from '../src/core/registry-client.js';
+import { getApiPrefix } from '../src/utils/registry-scope.js';
 
 async function main() {
   const registry = process.env.REGISTRY || 'http://localhost:3000';
@@ -23,7 +24,7 @@ async function main() {
   console.log(`Version: ${version}`);
   console.log('');
 
-  const client = new RegistryClient({ registry });
+  const client = new RegistryClient({ registry, apiPrefix: getApiPrefix(registry) });
 
   try {
     // 1. 解析版本

--- a/src/cli/commands/__integration__/publish.test.ts
+++ b/src/cli/commands/__integration__/publish.test.ts
@@ -521,7 +521,7 @@ compatibility: cursor >=0.40
       createValidSkillMd();
 
       const result = runCli(
-        'publish --dry-run --registry https://reskill-test.zhenguanyu.com',
+        'publish --dry-run --registry https://rush-test.zhenguanyu.com',
         tempDir,
       );
 

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -10,6 +10,7 @@ import { AuthManager } from '../../core/auth-manager.js';
 import { RegistryClient, RegistryError } from '../../core/registry-client.js';
 import { logger } from '../../utils/logger.js';
 import { resolveRegistry } from '../../utils/registry.js';
+import { getApiPrefix } from '../../utils/registry-scope.js';
 
 // ============================================================================
 // Types
@@ -54,7 +55,7 @@ async function loginWithToken(
   logger.newline();
 
   // Verify token by calling login-cli endpoint
-  const client = new RegistryClient({ registry, token });
+  const client = new RegistryClient({ registry, token, apiPrefix: getApiPrefix(registry) });
 
   try {
     const response = await client.loginCli();

--- a/src/cli/commands/publish.test.ts
+++ b/src/cli/commands/publish.test.ts
@@ -60,7 +60,7 @@ describe('publish command', () => {
 
     describe('should allow private registries', () => {
       it('should allow custom private domain', () => {
-        expect(isBlockedPublicRegistry('https://reskill-test.zhenguanyu.com')).toBe(false);
+        expect(isBlockedPublicRegistry('https://rush-test.zhenguanyu.com')).toBe(false);
       });
 
       it('should allow localhost', () => {
@@ -116,7 +116,7 @@ describe('publish command', () => {
       it('should build skill name with registry scope for kanyun registry', () => {
         const result = buildPublishSkillName(
           'planning-with-files',
-          'https://reskill-test.zhenguanyu.com/',
+          'https://rush-test.zhenguanyu.com/',
           'wangzirenbj',
         );
         // Should use @kanyun (registry scope), not @wangzirenbj (user handle)
@@ -126,7 +126,16 @@ describe('publish command', () => {
       it('should handle registry without trailing slash', () => {
         const result = buildPublishSkillName(
           'my-skill',
-          'https://reskill-test.zhenguanyu.com',
+          'https://rush-test.zhenguanyu.com',
+          'someuser',
+        );
+        expect(result).toBe('@kanyun/my-skill');
+      });
+
+      it('should work with rush.zhenguanyu.com (production)', () => {
+        const result = buildPublishSkillName(
+          'my-skill',
+          'https://rush.zhenguanyu.com/',
           'someuser',
         );
         expect(result).toBe('@kanyun/my-skill');
@@ -146,7 +155,7 @@ describe('publish command', () => {
       it('should keep existing scope if name already has one', () => {
         const result = buildPublishSkillName(
           '@existing/my-skill',
-          'https://reskill-test.zhenguanyu.com/',
+          'https://rush-test.zhenguanyu.com/',
           'wangzirenbj',
         );
         // Should preserve existing scope
@@ -160,8 +169,12 @@ describe('publish command', () => {
   // ============================================================================
 
   describe('getScopeForRegistry', () => {
-    it('should return @kanyun for reskill-test.zhenguanyu.com', () => {
-      expect(getScopeForRegistry('https://reskill-test.zhenguanyu.com/')).toBe('@kanyun');
+    it('should return @kanyun for rush-test.zhenguanyu.com', () => {
+      expect(getScopeForRegistry('https://rush-test.zhenguanyu.com/')).toBe('@kanyun');
+    });
+
+    it('should return @kanyun for rush.zhenguanyu.com', () => {
+      expect(getScopeForRegistry('https://rush.zhenguanyu.com/')).toBe('@kanyun');
     });
 
     it('should return null for unknown registry', () => {

--- a/src/cli/commands/publish.ts
+++ b/src/cli/commands/publish.ts
@@ -25,7 +25,7 @@ import {
 } from '../../core/skill-validator.js';
 import { logger } from '../../utils/logger.js';
 import { resolveRegistry } from '../../utils/registry.js';
-import { buildFullSkillName, getScopeForRegistry } from '../../utils/registry-scope.js';
+import { buildFullSkillName, getApiPrefix, getScopeForRegistry } from '../../utils/registry-scope.js';
 
 // ============================================================================
 // Types
@@ -612,7 +612,7 @@ async function publishAction(skillPath: string, options: PublishOptions): Promis
     logger.newline();
     logger.log(`Publishing to ${registry}...`);
 
-    const client = new RegistryClient({ registry, token });
+    const client = new RegistryClient({ registry, token, apiPrefix: getApiPrefix(registry) });
 
     try {
       // Get skill name from SKILL.md (primary source per agentskills.io spec)

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -9,6 +9,7 @@ import { AuthManager } from '../../core/auth-manager.js';
 import { RegistryClient, RegistryError } from '../../core/registry-client.js';
 import { logger } from '../../utils/logger.js';
 import { resolveRegistry } from '../../utils/registry.js';
+import { getApiPrefix } from '../../utils/registry-scope.js';
 
 // ============================================================================
 // Types
@@ -36,7 +37,7 @@ async function whoamiAction(options: WhoamiOptions): Promise<void> {
   }
 
   // Verify with server
-  const client = new RegistryClient({ registry, token });
+  const client = new RegistryClient({ registry, token, apiPrefix: getApiPrefix(registry) });
 
   try {
     const response = await client.whoami();

--- a/src/core/registry-resolver.ts
+++ b/src/core/registry-resolver.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  getApiPrefix,
   getRegistryUrl,
   getShortName,
   type ParsedSkillIdentifier,
@@ -115,7 +116,7 @@ export class RegistryResolver {
     const registryUrl = getRegistryUrl(parsed.scope);
 
     // 3. 创建 client 并解析版本
-    const client = new RegistryClient({ registry: registryUrl });
+    const client = new RegistryClient({ registry: registryUrl, apiPrefix: getApiPrefix(registryUrl) });
     const version = await client.resolveVersion(parsed.fullName, parsed.version);
 
     // 4. 下载 tarball

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -11,7 +11,7 @@ import {
   remove,
 } from '../utils/fs.js';
 import { logger } from '../utils/logger.js';
-import { getRegistryUrl, parseSkillIdentifier } from '../utils/registry-scope.js';
+import { getApiPrefix, getRegistryUrl, parseSkillIdentifier } from '../utils/registry-scope.js';
 import {
   type AgentType,
   agents,
@@ -938,7 +938,7 @@ export class SkillManager {
     // 解析 skill 标识（获取 fullName 和 version）
     const parsed = parseSkillIdentifier(ref);
     const registryUrl = getRegistryUrl(parsed.scope);
-    const client = new RegistryClient({ registry: registryUrl });
+    const client = new RegistryClient({ registry: registryUrl, apiPrefix: getApiPrefix(registryUrl) });
 
     // 新增：先查询 skill 信息获取 source_type
     let skillInfo: SkillInfo;
@@ -1137,7 +1137,8 @@ export class SkillManager {
   /**
    * 安装 Local Folder 模式发布的 skill
    *
-   * 通过 Registry 的 /api/skills/:name/download API 下载 tarball
+   * 通过 Registry 的 {apiPrefix}/skills/:name/download API 下载 tarball
+   * (apiPrefix 根据 registry 不同而不同，如 /api 或 /api/reskill)
    */
   private async installFromRegistryLocal(
     _skillInfo: SkillInfo, // 保留参数以便未来扩展（如日志记录）

--- a/src/utils/registry-scope.test.ts
+++ b/src/utils/registry-scope.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildFullSkillName,
+  getApiPrefix,
   getRegistryForScope,
   getRegistryUrl,
   getScopeForRegistry,
@@ -17,12 +18,58 @@ import {
 } from './registry-scope.js';
 
 describe('registry-scope', () => {
-  describe('getScopeForRegistry', () => {
-    it('should return @kanyun for reskill-test.zhenguanyu.com', () => {
-      expect(getScopeForRegistry('https://reskill-test.zhenguanyu.com')).toBe('@kanyun');
+  describe('getApiPrefix', () => {
+    it('should return /api/reskill for rush-test.zhenguanyu.com', () => {
+      expect(getApiPrefix('https://rush-test.zhenguanyu.com')).toBe('/api/reskill');
+    });
+
+    it('should return /api/reskill for rush.zhenguanyu.com', () => {
+      expect(getApiPrefix('https://rush.zhenguanyu.com')).toBe('/api/reskill');
     });
 
     it('should handle trailing slash', () => {
+      expect(getApiPrefix('https://rush-test.zhenguanyu.com/')).toBe('/api/reskill');
+    });
+
+    it('should return /api/reskill for localhost:3000', () => {
+      expect(getApiPrefix('http://localhost:3000')).toBe('/api/reskill');
+    });
+
+    it('should return /api for reskill-test.zhenguanyu.com (legacy reskill-app)', () => {
+      expect(getApiPrefix('https://reskill-test.zhenguanyu.com')).toBe('/api');
+    });
+
+    it('should return /api for public registry', () => {
+      expect(getApiPrefix('https://reskill.info')).toBe('/api');
+    });
+
+    it('should return /api for unknown registry', () => {
+      expect(getApiPrefix('https://unknown.com')).toBe('/api');
+    });
+
+    it('should return /api for empty string', () => {
+      expect(getApiPrefix('')).toBe('/api');
+    });
+  });
+
+  describe('getScopeForRegistry', () => {
+    it('should return @kanyun for rush-test.zhenguanyu.com', () => {
+      expect(getScopeForRegistry('https://rush-test.zhenguanyu.com')).toBe('@kanyun');
+    });
+
+    it('should return @kanyun for rush.zhenguanyu.com', () => {
+      expect(getScopeForRegistry('https://rush.zhenguanyu.com')).toBe('@kanyun');
+    });
+
+    it('should handle trailing slash', () => {
+      expect(getScopeForRegistry('https://rush-test.zhenguanyu.com/')).toBe('@kanyun');
+    });
+
+    it('should return @kanyun for reskill-test.zhenguanyu.com (legacy)', () => {
+      expect(getScopeForRegistry('https://reskill-test.zhenguanyu.com')).toBe('@kanyun');
+    });
+
+    it('should return @kanyun for reskill-test.zhenguanyu.com/ with trailing slash', () => {
       expect(getScopeForRegistry('https://reskill-test.zhenguanyu.com/')).toBe('@kanyun');
     });
 
@@ -39,12 +86,12 @@ describe('registry-scope', () => {
     describe('without custom scopeRegistries (backward compatibility)', () => {
       it('should return registry for known scope @kanyun', () => {
         const registry = getRegistryForScope('@kanyun');
-        expect(registry).toBe('https://reskill-test.zhenguanyu.com/');
+        expect(registry).toBe('https://rush-test.zhenguanyu.com/');
       });
 
       it('should handle scope without @ prefix', () => {
         const registry = getRegistryForScope('kanyun');
-        expect(registry).toBe('https://reskill-test.zhenguanyu.com/');
+        expect(registry).toBe('https://rush-test.zhenguanyu.com/');
       });
 
       it('should return null for unknown scope', () => {
@@ -78,7 +125,7 @@ describe('registry-scope', () => {
           '@other': 'https://other.com/',
         };
         const registry = getRegistryForScope('@kanyun', customRegistries);
-        expect(registry).toBe('https://reskill-test.zhenguanyu.com/');
+        expect(registry).toBe('https://rush-test.zhenguanyu.com/');
       });
 
       it('should return null if scope not found in custom or hardcoded', () => {
@@ -122,12 +169,12 @@ describe('registry-scope', () => {
     describe('private registry (with scope) - backward compatibility', () => {
       it('should resolve registry from known scope @kanyun', () => {
         const registry = getRegistryUrl('@kanyun');
-        expect(registry).toBe('https://reskill-test.zhenguanyu.com/');
+        expect(registry).toBe('https://rush-test.zhenguanyu.com/');
       });
 
       it('should handle scope without @ prefix', () => {
         const registry = getRegistryUrl('kanyun');
-        expect(registry).toBe('https://reskill-test.zhenguanyu.com/');
+        expect(registry).toBe('https://rush-test.zhenguanyu.com/');
       });
 
       it('should throw error for unknown scope', () => {
@@ -166,7 +213,7 @@ describe('registry-scope', () => {
           '@other': 'https://other.com/',
         };
         const url = getRegistryUrl('@kanyun', customRegistries);
-        expect(url).toBe('https://reskill-test.zhenguanyu.com/');
+        expect(url).toBe('https://rush-test.zhenguanyu.com/');
       });
 
       it('should throw error for unknown scope not in custom or hardcoded', () => {

--- a/src/utils/registry-scope.ts
+++ b/src/utils/registry-scope.ts
@@ -16,12 +16,47 @@ export const PUBLIC_REGISTRY = 'https://reskill.info/';
  * TODO: Replace with dynamic fetching from /api/registry/info
  */
 const REGISTRY_SCOPE_MAP: Record<string, string> = {
+  // rush-app (private registry, new)
+  'https://rush-test.zhenguanyu.com': '@kanyun',
+  'https://rush.zhenguanyu.com': '@kanyun',
+  // reskill-app (private registry, legacy)
   'https://reskill-test.zhenguanyu.com': '@kanyun',
-  'https://reskill-test.zhenguanyu.com/': '@kanyun',
   // Local development
   'http://localhost:3000': '@kanyun',
-  'http://localhost:3000/': '@kanyun',
 };
+
+/**
+ * Registry API prefix mapping
+ *
+ * rush-app hosts reskill APIs under /api/reskill/ prefix.
+ * Default for unlisted registries: '/api'
+ */
+const REGISTRY_API_PREFIX: Record<string, string> = {
+  'https://rush-test.zhenguanyu.com': '/api/reskill',
+  'https://rush.zhenguanyu.com': '/api/reskill',
+  'http://localhost:3000': '/api/reskill',
+  // Note: reskill-test.zhenguanyu.com (legacy reskill-app) is intentionally
+  // NOT listed here — it uses the default '/api' prefix.
+};
+
+/**
+ * Get the API path prefix for a given registry URL
+ *
+ * @param registryUrl - Registry URL
+ * @returns API prefix string (e.g., '/api' or '/api/reskill')
+ *
+ * @example
+ * getApiPrefix('https://rush-test.zhenguanyu.com') // '/api/reskill'
+ * getApiPrefix('https://reskill.info') // '/api'
+ * getApiPrefix('https://unknown.com') // '/api'
+ */
+export function getApiPrefix(registryUrl: string): string {
+  if (!registryUrl) {
+    return '/api';
+  }
+  const normalized = registryUrl.endsWith('/') ? registryUrl.slice(0, -1) : registryUrl;
+  return REGISTRY_API_PREFIX[normalized] || '/api';
+}
 
 /**
  * Parsed skill name result
@@ -57,7 +92,7 @@ export interface ParsedSkillIdentifier {
  * @returns Scope string (e.g., "@kanyun") or null if not found
  *
  * @example
- * getScopeForRegistry('https://reskill-test.zhenguanyu.com') // '@kanyun'
+ * getScopeForRegistry('https://rush-test.zhenguanyu.com') // '@kanyun'
  * getScopeForRegistry('https://unknown.com') // null
  */
 export function getScopeForRegistry(registry: string): string | null {
@@ -90,8 +125,8 @@ export type ScopeRegistries = Record<string, string>;
  * @returns Registry URL (with trailing slash) or null if not found
  *
  * @example
- * getRegistryForScope('@kanyun') // 'https://reskill-test.zhenguanyu.com/'
- * getRegistryForScope('kanyun') // 'https://reskill-test.zhenguanyu.com/'
+ * getRegistryForScope('@kanyun') // 'https://rush-test.zhenguanyu.com/'
+ * getRegistryForScope('kanyun') // 'https://rush-test.zhenguanyu.com/'
  * getRegistryForScope('@unknown') // null
  * getRegistryForScope('@mycompany', { '@mycompany': 'https://my.registry.com/' }) // 'https://my.registry.com/'
  */
@@ -136,8 +171,8 @@ export function getRegistryForScope(
  * @throws Error if scope is provided but not found in the registry map
  *
  * @example
- * getRegistryUrl('@kanyun') // 'https://reskill-test.zhenguanyu.com/'
- * getRegistryUrl('kanyun') // 'https://reskill-test.zhenguanyu.com/'
+ * getRegistryUrl('@kanyun') // 'https://rush-test.zhenguanyu.com/'
+ * getRegistryUrl('kanyun') // 'https://rush-test.zhenguanyu.com/'
  * getRegistryUrl(null) // 'https://reskill.info/'
  * getRegistryUrl('') // 'https://reskill.info/'
  * getRegistryUrl('@unknown') // throws Error


### PR DESCRIPTION
…refix

- Add REGISTRY_API_PREFIX mapping and getApiPrefix() for dynamic API path resolution
- Add apiPrefix option to RegistryClient with trailing slash normalization
- Handle 302/301 redirect in downloadSkill() to capture x-integrity header
- Add rush-test.zhenguanyu.com and rush.zhenguanyu.com domain mappings
- Preserve backward compatibility with legacy reskill-test.zhenguanyu.com
- Fix double-slash bug in API URLs when registry URL has trailing slash