### PR TITLE
feat(ci): add beta release workflow for feature branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,8 +62,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -82,14 +80,28 @@ jobs:
         id: check-pre
         run: |
           if [ -f ".changeset/pre.json" ]; then
-            echo "is_pre=true" >> $GITHUB_OUTPUT
+            TAG=$(jq -r '.tag' .changeset/pre.json)
+            if [ "$TAG" = "beta" ]; then
+              echo "is_pre=true" >> $GITHUB_OUTPUT
+            else
+              echo "::warning::pre.json exists but tag is '$TAG', expected 'beta'. Skipping."
+              echo "is_pre=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "is_pre=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Skip notice
+        if: steps.check-pre.outputs.is_pre != 'true'
+        run: echo "::notice::Not in beta pre-release mode. Skipping beta publish."
+
       - name: Version packages (beta)
         if: steps.check-pre.outputs.is_pre == 'true'
         run: pnpm changeset version
+
+      - name: Run tests
+        if: steps.check-pre.outputs.is_pre == 'true'
+        run: pnpm test:run
 
       - name: Build
         if: steps.check-pre.outputs.is_pre == 'true'


### PR DESCRIPTION
## Summary
Add automated beta publishing when pushing to `feature-*` branches using Changesets pre-release mode.

## Changes
- **Trigger**: Release workflow now runs on `main` and `feature-*` branches.
- **Release job**: Runs only on `main` (unchanged behavior: Version PR or publish).
- **Beta-release job**: Runs on `feature-*` branches; when `.changeset/pre.json` exists:
  - `pnpm changeset version` (beta version bump)
  - `pnpm build`
  - `pnpm changeset publish --tag beta`

## Usage
# On a feature branch, enter pre-release mode
pnpm changeset pre enter beta
git add .changeset/pre.json && git commit -m "chore: enter beta pre-release mode"

# Add changesets and push → CI publishes to npm with `beta` tag
pnpm changeset
git add . && git commit -m "feat: ..."
git push

# When done, exit pre-release and merge to main for stable release
pnpm changeset pre exit
