### PR TITLE
fix(ci): remove --tag flag from beta publish in pre mode

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Publish beta to npm
         if: steps.check-pre.outputs.is_pre == 'true'
-        run: pnpm changeset publish --tag beta
+        run: pnpm changeset publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Changeset pre mode automatically uses the tag from pre.json as the npm dist-tag, making the explicit --tag beta flag redundant and causing a conflict error: "Releasing under custom tag is not allowed in pre mode".