### PR TITLE
fix(core): strip #skillName fragment from git clone URL in reinstall/update

### DIFF
--- a/.changeset/fix-multi-skill-reinstall-update.md
+++ b/.changeset/fix-multi-skill-reinstall-update.md
@@ -1,0 +1,35 @@
+---
+"reskill": patch
+---
+
+Fix reinstall/update failure for multi-skill repo references with #skillName fragment
+
+**Bug:**
+When `skills.json` stores references in `github:user/repo#skillName` format (saved during multi-skill repo installation), running `install` (no args, reinstall all) or `update` would append `#skillName` to the git clone URL, causing a clone failure like: `Failed to clone repository: https://github.com/anthropics/skills#pdf`.
+
+**Changes:**
+- Strip `#fragment` in `parseRef()` before URL construction, storing it as `skillName` on `ParsedSkillRef`
+- Add `resolveSourcePath()` helper to locate the correct skill subdirectory in cached multi-skill repos
+- Use `resolveSourcePath()` in both `installFromGit()` and `installToAgentsFromGit()` so reinstall and update correctly find the skill within the cloned repo
+
+**Bug Fixes:**
+- `install` (reinstall all from skills.json) now works with `ref#skillName` entries
+- `update <skill>` now works with `ref#skillName` entries
+- `outdated` check no longer fails on `ref#skillName` entries
+
+---
+
+修复多技能仓库 #skillName 格式引用的 reinstall/update 失败问题
+
+**Bug:**
+当 `skills.json` 中存储了 `github:user/repo#skillName` 格式的引用（多技能仓库安装时保存），执行 `install`（无参数重装全部）或 `update` 时，会将 `#skillName` 拼接到 git clone URL 中，导致克隆失败，例如：`Failed to clone repository: https://github.com/anthropics/skills#pdf`。
+
+**Changes:**
+- 在 `parseRef()` 中构建 URL 前剥离 `#fragment`，存入 `ParsedSkillRef.skillName` 字段
+- 新增 `resolveSourcePath()` 辅助方法，在缓存的多技能仓库中定位正确的 skill 子目录
+- 在 `installFromGit()` 和 `installToAgentsFromGit()` 中使用 `resolveSourcePath()`，使 reinstall 和 update 能正确找到仓库中的 skill
+
+**Bug Fixes:**
+- `install`（从 skills.json 重装全部）现在可以正确处理 `ref#skillName` 条目
+- `update <skill>` 现在可以正确处理 `ref#skillName` 条目
+- `outdated` 检查不再因 `ref#skillName` 条目而失败

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -1134,22 +1134,26 @@ describe('runDoctorChecks', () => {
     expect(checkNames).toContain('Installed skills');
   });
 
-  it('should run all checks including network', async () => {
-    const results = await runDoctorChecks({
-      cwd: testDir,
-      packageName: 'reskill',
-      packageVersion: '0.17.0',
-      skipNetwork: false,
-      skipConfigChecks: true,
-    });
+  it(
+    'should run all checks including network',
+    async () => {
+      const results = await runDoctorChecks({
+        cwd: testDir,
+        packageName: 'reskill',
+        packageVersion: '0.17.0',
+        skipNetwork: false,
+        skipConfigChecks: true,
+      });
 
-    // Should have 10 checks with network
-    expect(results.length).toBe(10);
+      // Should have 10 checks with network
+      expect(results.length).toBe(10);
 
-    const checkNames = results.map((r) => r.name);
-    expect(checkNames.some((n) => n.includes('github.com'))).toBe(true);
-    expect(checkNames.some((n) => n.includes('gitlab.com'))).toBe(true);
-  });
+      const checkNames = results.map((r) => r.name);
+      expect(checkNames.some((n) => n.includes('github.com'))).toBe(true);
+      expect(checkNames.some((n) => n.includes('gitlab.com'))).toBe(true);
+    },
+    30_000,
+  );
 
   it('should include config checks when not skipped', async () => {
     // Create a skills.json with issues

--- a/src/core/git-resolver.test.ts
+++ b/src/core/git-resolver.test.ts
@@ -68,6 +68,28 @@ describe('GitResolver', () => {
     it('should throw for invalid ref', () => {
       expect(() => resolver.parseRef('invalid')).toThrow('Invalid skill reference');
     });
+
+    describe('parseRef with #skillName fragment', () => {
+      it('should strip #fragment and set skillName', () => {
+        const result = resolver.parseRef('github:anthropics/skills#pdf');
+        expect(result.repo).toBe('skills');
+        expect(result.skillName).toBe('pdf');
+        expect(result.owner).toBe('anthropics');
+        expect(result.registry).toBe('github');
+      });
+
+      it('should strip #fragment with version', () => {
+        const result = resolver.parseRef('github:anthropics/skills@v1.0.0#pdf');
+        expect(result.repo).toBe('skills');
+        expect(result.skillName).toBe('pdf');
+        expect(result.version).toBe('v1.0.0');
+      });
+
+      it('should leave skillName undefined when no fragment', () => {
+        const result = resolver.parseRef('github:anthropics/skills');
+        expect(result.skillName).toBeUndefined();
+      });
+    });
   });
 
   describe('parseVersion', () => {

--- a/src/core/git-resolver.ts
+++ b/src/core/git-resolver.ts
@@ -96,11 +96,20 @@ export class GitResolver {
   parseRef(ref: string): ParsedSkillRef {
     const raw = ref;
 
+    // Extract #skillName fragment before any parsing (for both Git URLs and shorthand)
+    let skillName: string | undefined;
+    const hashIndex = ref.indexOf('#');
+    if (hashIndex >= 0) {
+      skillName = ref.slice(hashIndex + 1);
+      ref = ref.slice(0, hashIndex);
+    }
+
     // First check if it's a Git URL (SSH, HTTPS, git://)
     // For Git URLs, need special handling for version separator
     // Format: git@host:user/repo.git[@version] or git@host:user/repo.git/subpath[@version]
     if (isGitUrl(ref)) {
-      return this.parseGitUrlRef(ref);
+      const parsed = this.parseGitUrlRef(ref);
+      return { ...parsed, raw, skillName };
     }
 
     // Standard format parsing for non-Git URLs
@@ -154,6 +163,7 @@ export class GitResolver {
       subPath,
       version,
       raw,
+      skillName,
     };
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -209,6 +209,8 @@ export interface ParsedSkillRef {
   raw: string;
   /** Full Git URL (SSH/HTTPS), if provided */
   gitUrl?: string;
+  /** Skill name from #fragment (multi-skill repo selector) */
+  skillName?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix `install` (reinstall all) and `update` failing for multi-skill repo references stored as `github:user/repo#skillName` in `skills.json`
- The `#skillName` fragment was being appended to the git clone URL, causing errors like: `Failed to clone repository: https://github.com/anthropics/skills#pdf`
- Now `parseRef()` strips the `#fragment` before URL construction and a new `resolveSourcePath()` helper locates the correct skill subdirectory in cached multi-skill repos

## Root Cause

When installing from a multi-skill repo (`reskill install github:org/repo --skill pdf`), the ref is saved to `skills.json` as `github:org/repo#pdf`. On subsequent `install` (no args) or `update`, this ref was passed directly to `parseRef()` which did not recognize `#` — it became part of the repo name (`skills#pdf`), producing an invalid clone URL.

## Changes

| File | Change |
|------|--------|
| `src/types/index.ts` | Add `skillName?: string` to `ParsedSkillRef` |
| `src/core/git-resolver.ts` | Strip `#fragment` in `parseRef()` before URL construction, store as `skillName` |
| `src/core/skill-manager.ts` | Add `resolveSourcePath()` helper; use it in `installFromGit()` and `installToAgentsFromGit()` to locate skill subdirectory |
| `src/core/git-resolver.test.ts` | 3 unit tests for `#fragment` handling in `parseRef()` |
| `src/cli/commands/__integration__/install-multi-skill.test.ts` | 2 integration tests: reinstall all + update with `ref#skillName` |
| `src/cli/commands/doctor.test.ts` | Increase network test timeout (flaky unrelated fix) |

## Test plan

- [x] Unit tests: `parseRef()` correctly strips `#fragment`, sets `skillName`, repo name is clean
- [x] Integration tests: reinstall all and update with `ref#skillName` entries in `skills.json`
- [x] Manual verification with `vercel-labs/agent-skills` (real multi-skill repo): `--list`, `--skill`, reinstall all, update, outdated all pass
- [x] `pnpm test:run` — all unit tests pass
- [x] `pnpm test:integration` — all integration tests pass
- [x] `pnpm typecheck` — no type errors


Made with [Cursor](https://cursor.com)