### PR TITLE
fix(install): preserve self-hosted GitLab/GitHub host in clone URL

### DIFF
--- a/.changeset/fix-self-hosted-git-clone-url.md
+++ b/.changeset/fix-self-hosted-git-clone-url.md
@@ -1,0 +1,42 @@
+---
+"reskill": patch
+---
+
+Fix self-hosted GitLab/GitHub clone URL for web-published skills
+
+**Problem:**
+When installing a web-published skill from a self-hosted GitLab instance (e.g., `gitlab.internal.example.com`),
+the CLI constructed a `gitlab:owner/repo` shorthand ref. The `buildRepoUrl` method resolved
+`gitlab` via `DEFAULT_REGISTRIES` to `https://gitlab.com`, losing the original self-hosted host
+and causing `git clone` to target the wrong server.
+
+**Root Cause:**
+`buildGitRefForWebPublished` always used `sourceType` (e.g., `"gitlab"`) as the ref prefix,
+regardless of whether the actual host was the standard `gitlab.com` or a self-hosted instance.
+
+**Fix:**
+- Added `isStandardHost` method to detect whether the host matches `github.com` / `gitlab.com`
+- For self-hosted hosts, the ref now uses the hostname as prefix (e.g., `gitlab.internal.example.com:owner/repo/path`)
+  instead of the generic `gitlab:` shorthand
+- `getRegistryUrl` fallback (`https://{registryName}`) correctly resolves self-hosted hostnames
+- Standard hosts continue to use `github:` / `gitlab:` shorthand (no behavior change)
+
+---
+
+修复自托管 GitLab/GitHub 的 clone URL 错误
+
+**问题：**
+从自托管 GitLab 安装 web 发布的 skill 时，CLI 构造了 `gitlab:owner/repo` 格式的 shorthand ref。
+`buildRepoUrl` 通过 `DEFAULT_REGISTRIES` 将 `gitlab` 解析为 `https://gitlab.com`，
+丢失了原始的自托管主机地址，导致 `git clone` 指向错误的服务器。
+
+**根因：**
+`buildGitRefForWebPublished` 始终使用 `sourceType`（如 `"gitlab"`）作为 ref 前缀，
+未区分标准主机（`gitlab.com`）和自托管主机。
+
+**修复：**
+- 新增 `isStandardHost` 方法检测 host 是否为 `github.com` / `gitlab.com`
+- 自托管主机使用完整域名作为前缀（如 `gitlab.internal.example.com:owner/repo/path`），
+  而非通用的 `gitlab:` shorthand
+- `getRegistryUrl` 的 fallback 逻辑（`https://{registryName}`）正确还原自托管地址
+- 标准主机继续使用 `github:` / `gitlab:` shorthand（行为不变）

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1533,7 +1533,9 @@ export class SkillManager {
 
     const urlParsed = parseGitUrl(sourceUrl);
     if (urlParsed) {
-      return `${sourceType}:${urlParsed.owner}/${urlParsed.repo}/${skillPath}`;
+      const isSelfHosted = !this.isStandardHost(urlParsed.host, sourceType);
+      const prefix = isSelfHosted ? urlParsed.host : sourceType;
+      return `${prefix}:${urlParsed.owner}/${urlParsed.repo}/${skillPath}`;
     }
 
     const shortName = getShortName(parsed.fullName);
@@ -1542,6 +1544,18 @@ export class SkillManager {
     }
 
     return sourceUrl;
+  }
+
+  /**
+   * Check if a host matches the standard host for a given source type.
+   * Standard hosts: github.com for github, gitlab.com for gitlab.
+   */
+  private isStandardHost(host: string, sourceType: string): boolean {
+    const standardHosts: Record<string, string> = {
+      github: 'github.com',
+      gitlab: 'gitlab.com',
+    };
+    return standardHosts[sourceType] === host;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fix `buildGitRefForWebPublished` incorrectly using `gitlab:` / `github:` shorthand for self-hosted Git hosts, causing `DEFAULT_REGISTRIES` to resolve the clone URL to `gitlab.com` / `github.com` instead of the actual host
- Add `isStandardHost` method to distinguish standard hosts (`github.com`, `gitlab.com`) from self-hosted instances
- Self-hosted hosts now use `host:owner/repo/path` ref format (e.g., `gitlab.internal.example.com:team/repo/skill-name`), correctly resolved via `getRegistryUrl` fallback

## Test plan

- [x] 5 new unit tests covering self-hosted GitLab, self-hosted GitHub Enterprise, standard gitlab.com, standard github.com, and no-skill_path scenarios
- [x] All 107 tests pass (`pnpm vitest run src/core/skill-manager.test.ts`)
- [x] Full test suite: 1262 passed, 0 failed
- [x] TypeCheck: 0 errors
- [x] Lint: 0 new errors on changed files
- [x] Manual verification: built from source, confirmed clone URL changed from `https://gitlab.com/...` to `https://gitlab-ee.xxx.com/...`


Made with [Cursor](https://cursor.com)