### PR TITLE
Login token interactive mode

### DIFF
--- a/.changeset/login-token-mask.md
+++ b/.changeset/login-token-mask.md
@@ -1,0 +1,23 @@
+---
+"reskill": minor
+---
+
+Add interactive token prompt for `login` command
+
+**Changes:**
+- `reskill login` now guides users through token setup with step-by-step instructions and a link to the registry's token settings page
+- Token input uses a fixed-length mask (`••••••••`) for visual feedback without revealing token length
+- Empty input shows "Token cannot be empty" warning and retries instead of exiting
+- Non-interactive mode (`reskill login --token <token>`) available for CI/CD pipelines
+- Updated README to document both interactive and non-interactive login modes
+
+---
+
+为 `login` 命令添加交互式 token 输入
+
+**变更:**
+- `reskill login` 现在会引导用户完成 token 设置，提供分步说明和 registry token 设置页面链接
+- Token 输入使用固定长度遮盖符（`••••••••`），提供视觉反馈且不暴露 token 长度
+- 空输入会提示 "Token cannot be empty" 并重试，而不是直接退出
+- 非交互式模式（`reskill login --token <token>`）适用于 CI/CD 流水线
+- 更新 README 文档，说明交互式和非交互式两种登录方式

--- a/.cursor/rules/collaboration.mdc
+++ b/.cursor/rules/collaboration.mdc
@@ -34,6 +34,10 @@ alwaysApply: true
   3. Never skip the RED step — a test that never failed proves nothing
   4. After fix: build and run `node dist/cli/index.js <command>` to manually verify the actual CLI behavior matches expectations
 - Commit only when explicitly asked
+- Before creating a commit, always check:
+  1. **Changeset**: If the change affects public behavior (bug fix / feature / breaking), create a changeset file in `.changeset/` following the bilingual format in `development.mdc`
+  2. **README**: If CLI command behavior, options, or output changed, check if `README.md` needs updating
+  3. **Docs**: If the change introduces new concepts or modifies architecture, check if `docs/` or `CLAUDE.md` need updating
 
 ## What I Value
 

--- a/.cursor/rules/development.mdc
+++ b/.cursor/rules/development.mdc
@@ -188,6 +188,10 @@ When creating or modifying a CLI command, add both unit tests and integration te
 - Use conventional commit format: `type(scope): description`
 - Types: feat, fix, docs, style, refactor, test, chore
 - Keep commits focused and atomic
+- **Before committing**, check if the change requires:
+  - A **changeset** (see Changeset Guidelines below) for any public behavior change
+  - A **README update** if CLI commands, options, or output changed
+  - A **docs update** if architecture or new concepts were introduced
 
 ```
 feat(cli): add multi-agent support for install command

--- a/README.md
+++ b/README.md
@@ -208,8 +208,11 @@ Skills are installed to `.skills/` by default and can be integrated with any age
 Publish your skills to the registry for others to use:
 
 ```bash
-# Login to the registry
+# Interactive login (recommended for humans — guides you through token setup)
 reskill login
+
+# Non-interactive login (for CI/CD — pass token directly)
+reskill login --token <your-token>
 
 # Validate without publishing (dry run)
 reskill publish --dry-run

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -695,34 +695,52 @@ reskill login [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `-r, --registry <url>` | `https://registry.reskill.dev` | Registry URL |
-| `--token <token>` | - | Use token directly (for CI/CD) |
+| `-r, --registry <url>` | (from env or skills.json) | Registry URL |
+| `-t, --token <token>` | - | Use token directly (skips interactive prompt, for CI/CD) |
 
 ### Behavior
 
 | Scenario | Expected Behavior | Exit Code |
 |----------|-------------------|-----------|
-| Interactive login | Prompt for token, save to ~/.reskillrc | `0` |
-| `--token` provided | Save token, verify with registry | `0` |
-| Invalid token | Error: "Invalid token" | `1` |
-| Already logged in | Info: show current user, offer to re-login | `0` |
+| Interactive login (no `--token`) | Show token page URL, prompt for token, verify & save to ~/.reskillrc | `0` |
+| `--token` provided | Verify token with registry, save to ~/.reskillrc | `0` |
+| Invalid token | Error: "Token verification failed" | `1` |
+| User cancels prompt | Info: "Login cancelled" | `0` |
 
 ### Output
 
-**Interactive:**
+**Interactive (default):**
 ```
-? Enter your access token: ********
+  Registry: https://registry.example.com
 
-Verifying token...
-✓ Logged in as octocat (octocat@github.com)
+  To get your access token:
+    1. Open https://registry.example.com/skills/tokens
+    2. Login and generate an API token
+    3. Copy the token and paste it below
+
+  Paste your access token: ••••••••
+
+Verifying token with https://registry.example.com...
+
+✓ Token verified and saved!
+  Handle: @octocat
+  Username: octocat
+  Email: octocat@github.com
+  Registry: https://registry.example.com
 
 Token saved to ~/.reskillrc
 ```
 
-**With --token:**
+**With --token (non-interactive):**
 ```
-Verifying token...
-✓ Logged in as octocat (octocat@github.com)
+Verifying token with https://registry.example.com...
+
+✓ Token verified and saved!
+  Handle: @octocat
+  Username: octocat
+  Registry: https://registry.example.com
+
+Token saved to ~/.reskillrc
 ```
 
 ### Configuration File

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -1,8 +1,11 @@
 /**
  * login command - Authenticate with a reskill registry
  *
- * Token-only login: requires a pre-generated token from Web UI.
- * Logs in to the registry and stores the token in ~/.reskillrc
+ * Supports two modes:
+ * 1. Interactive: prompts user to paste token (default when no --token flag)
+ * 2. Non-interactive: uses --token flag directly (for CI/CD)
+ *
+ * Tokens are stored in ~/.reskillrc per registry.
  */
 
 import { Command } from 'commander';
@@ -21,6 +24,149 @@ interface LoginOptions {
 }
 
 // ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Build the token settings page URL for a registry
+ */
+export function getTokenPageUrl(registry: string): string {
+  const base = registry.endsWith('/') ? registry.slice(0, -1) : registry;
+  return `${base}/skills/tokens`;
+}
+
+const MASK = '••••••••';
+const CANCELLED = Symbol('cancelled');
+
+/**
+ * Erase N characters behind the cursor and clear to end of line.
+ */
+function eraseChars(count: number): void {
+  process.stdout.write(`\x1b[${count}D\x1b[0K`);
+}
+
+/**
+ * Read a line from piped stdin (non-TTY).
+ */
+function readFromPipe(): Promise<string | null> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const onData = (chunk: Buffer) => chunks.push(chunk);
+    const onEnd = () => {
+      cleanup();
+      const value = Buffer.concat(chunks).toString().trim();
+      resolve(value || null);
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const cleanup = () => {
+      process.stdin.removeListener('data', onData);
+      process.stdin.removeListener('end', onEnd);
+      process.stdin.removeListener('error', onError);
+    };
+
+    process.stdin.on('data', onData);
+    process.stdin.on('end', onEnd);
+    process.stdin.on('error', onError);
+    process.stdin.resume();
+  });
+}
+
+/**
+ * Read token from TTY stdin in raw mode with fixed-length mask feedback.
+ *
+ * Returns:
+ * - token string on valid input + Enter
+ * - empty string on empty Enter (no input)
+ * - CANCELLED symbol on Ctrl+C
+ */
+function readFromTTY(): Promise<string | typeof CANCELLED> {
+  return new Promise((resolve) => {
+    let input = '';
+    let masked = false;
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding('utf8');
+
+    const finish = (value: string | typeof CANCELLED) => {
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+      process.stdin.removeAllListeners('data');
+      process.stdout.write('\n');
+      resolve(value);
+    };
+
+    process.stdin.on('data', (data: string) => {
+      for (const ch of data) {
+        if (ch === '\r' || ch === '\n') {
+          return finish(input.trim());
+        }
+        if (ch === '\x03') {
+          return finish(CANCELLED);
+        }
+        if (ch === '\x7f' || ch === '\b') {
+          // Fixed-length mask can't represent per-char deletion — clear all to let user retry
+          if (input.length > 0) {
+            input = '';
+            if (masked) {
+              eraseChars(MASK.length);
+              masked = false;
+            }
+          }
+          continue;
+        }
+        if (ch >= ' ') {
+          input += ch;
+          if (!masked) {
+            process.stdout.write(MASK);
+            masked = true;
+          }
+        }
+      }
+    });
+  });
+}
+
+/**
+ * Prompt user to paste their access token interactively.
+ * Shows a fixed-length mask on input for visual feedback without revealing token length.
+ * Retries on empty input, returns null only on explicit cancel (Ctrl+C).
+ */
+export async function promptForToken(registry: string): Promise<string | null> {
+  const tokenPageUrl = getTokenPageUrl(registry);
+
+  logger.newline();
+  logger.log(`  Registry: ${registry}`);
+  logger.newline();
+  logger.log('  To get your access token:');
+  logger.log(`    1. Open ${tokenPageUrl}`);
+  logger.log('    2. Login and generate an API token');
+  logger.log('    3. Copy the token and paste it below');
+  logger.newline();
+
+  if (!process.stdin.isTTY) {
+    return readFromPipe();
+  }
+
+  while (true) {
+    process.stdout.write('  Paste your access token: ');
+    const result = await readFromTTY();
+
+    if (result === CANCELLED) {
+      return null;
+    }
+    if (result.length > 0) {
+      return result;
+    }
+
+    logger.warn('  Token cannot be empty. Please try again.');
+  }
+}
+
+// ============================================================================
 // Main Action
 // ============================================================================
 
@@ -28,18 +174,20 @@ async function loginAction(options: LoginOptions): Promise<void> {
   const registry = resolveRegistry(options.registry);
   const authManager = new AuthManager();
 
-  // Token is required (no email/password login)
-  if (!options.token) {
-    logger.error('Token is required');
-    logger.newline();
-    logger.log('To get a token:');
-    logger.log('  1. Visit the Registry Web UI');
-    logger.log('  2. Login and generate an API token');
-    logger.log('  3. Run: reskill login --registry <url> --token <token>');
-    process.exit(1);
+  let token: string;
+
+  if (options.token) {
+    token = options.token;
+  } else {
+    const prompted = await promptForToken(registry);
+    if (!prompted) {
+      logger.warn('Login cancelled');
+      process.exit(0);
+    }
+    token = prompted;
   }
 
-  await loginWithToken(options.token, registry, authManager);
+  await loginWithToken(token, registry, authManager);
 }
 
 /**
@@ -53,7 +201,6 @@ async function loginWithToken(
   logger.log(`Verifying token with ${registry}...`);
   logger.newline();
 
-  // Verify token by calling login-cli endpoint
   const client = new RegistryClient({ registry, token });
 
   try {
@@ -64,7 +211,6 @@ async function loginWithToken(
       process.exit(1);
     }
 
-    // Save token with handle and email
     authManager.setToken(token, registry, response.user.email, response.user.handle);
 
     logger.log('✓ Token verified and saved!');
@@ -100,7 +246,7 @@ export const loginCommand = new Command('login')
     '-r, --registry <url>',
     'Registry URL (or set RESKILL_REGISTRY env var, or defaults.publishRegistry in skills.json)',
   )
-  .option('-t, --token <token>', 'API token from Web UI (required)')
+  .option('-t, --token <token>', 'API token from Web UI (skips interactive prompt)')
   .action(loginAction);
 
 export default loginCommand;


### PR DESCRIPTION
## Summary

Implement interactive token input for the `login` command with improved UX:

- **Interactive login** (`reskill login`): Guides users through token setup with step-by-step instructions and a link to the token settings page. Uses a custom raw stdin reader with fixed-length mask (`••••••••`) for visual feedback without revealing token length.
- **Non-interactive login** (`reskill login --token <token>`): For CI/CD pipelines, pass the token directly.
- **Empty input handling**: Shows "Token cannot be empty" warning and retries, instead of treating it as cancellation.
- **Ctrl+C**: Properly cancels the login flow.

### Additional changes

- Replaced `@clack/prompts` password prompt (which showed one mask character per input character, causing 200+ char mask for JWTs) with a lightweight custom implementation
- Removed `@clack/prompts` dependency from the login command
- Updated README to document both interactive and non-interactive login modes
- Added pre-commit checklist to cursor rules (changeset / README / docs checks)

## Test plan

- [x] `reskill login --help` shows correct usage
- [x] Interactive mode: paste token → shows fixed `••••••••` mask → Enter confirms
- [x] Interactive mode: press Enter with no input → warns "Token cannot be empty" → retries
- [x] Interactive mode: Ctrl+C → shows "Login cancelled" → exits
- [x] Non-interactive mode: `--token` flag bypasses prompt
- [x] All unit tests pass (`pnpm test:run`)
- [x] Build succeeds (`pnpm build`)

---
[Slack Thread](https://ai-qk12624.slack.com/archives/C0AGY1E2L93/p1772016521030969?thread_ts=1772016521.030969&cid=C0AGY1E2L93)