### PR TITLE
feat(doctor): add 8 diagnostic checks to align with runtime dependencies

### DIFF
--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -870,20 +870,26 @@ The doctor command performs the following checks:
 | Node.js version | Verify Node.js >= 18.0.0 |
 | Git | Verify Git is installed |
 | Git authentication | Check for SSH keys or credential helper |
+| Registry auth | Check for `RESKILL_TOKEN` env var or `~/.reskillrc` token |
+| Environment vars | Report active reskill env vars (`RESKILL_TOKEN`, `RESKILL_REGISTRY`, `RESKILL_CACHE_DIR`) |
 
 **Directory Checks:**
 | Check | Description |
 |-------|-------------|
 | Cache directory | Show cache location and size |
 | skills.json | Verify configuration file exists and is valid |
-| skills.lock | Verify lock file is in sync with skills.json |
+| skills.lock | Verify lock file is in sync with skills.json and `lockfileVersion` is supported |
 | Installed skills | Check installed skills for issues |
+| Detected agents | Report agents detected on the system via `detectInstalledAgents()` |
 
 **Configuration Checks:**
 | Check | Description |
 |-------|-------------|
 | Registry conflict | Warn if `github` or `gitlab` registry names are overridden |
+| Invalid registry URL | Error if custom registry URL does not start with `http://` or `https://` |
 | Dangerous installDir | Error if installDir uses reserved paths (src, node_modules, etc.) |
+| Invalid installMode | Error if `defaults.installMode` is not `symlink` or `copy` |
+| Invalid publishRegistry | Warn if `defaults.publishRegistry` is not a valid URL |
 | Invalid agent | Warn for unknown agent types in targetAgents |
 | Invalid skill ref | Error for malformed skill references |
 | Version mismatch | Warn for monorepo skills with different versions |
@@ -893,6 +899,7 @@ The doctor command performs the following checks:
 |-------|-------------|
 | Network (github.com) | Test connectivity to GitHub |
 | Network (gitlab.com) | Test connectivity to GitLab |
+| Network (custom) | Test connectivity to custom registries and publishRegistry |
 
 ### Behavior
 
@@ -913,10 +920,13 @@ The doctor command performs the following checks:
 ✓ Node.js version          v22.0.0 (>=18.0.0 required)
 ✓ Git                      2.43.0
 ✓ Git authentication       SSH key found
+✓ Registry auth            ~/.reskillrc found
+✓ Environment vars         RESKILL_REGISTRY set
 ✓ Cache directory          ~/.reskill-cache (12.5 MB, 5 skills cached)
 ✓ skills.json              found (3 skills declared)
 ✓ skills.lock              in sync (3 skills locked)
 ✓ Installed skills         3 skills installed
+✓ Detected agents          3 detected: cursor, claude-code, windsurf
 ✓ Network (github.com)     reachable
 ✓ Network (gitlab.com)     reachable
 
@@ -932,15 +942,19 @@ All checks passed! reskill is ready to use.
 ✓ Git                      2.43.0
 ⚠ Git authentication       no SSH key or credential helper found
   → For private repos, add SSH key: ssh-keygen -t ed25519
+⚠ Registry auth            no token configured
+  → Run: reskill login (needed for publish and private skills)
+✓ Environment vars         none set
 ✓ Cache directory          ~/.reskill-cache (12.5 MB, 5 skills cached)
 ⚠ skills.json              not found
   → Run: reskill init
 ✓ skills.lock              n/a (no skills.json)
 ✓ Installed skills         none
+✓ Detected agents          1 detected: cursor
 ✓ Network (github.com)     reachable
 ✓ Network (gitlab.com)     reachable
 
-Found 2 warnings, but reskill should work
+Found 3 warnings, but reskill should work
 ```
 
 **With errors:**

--- a/src/cli/commands/__integration__/doctor.test.ts
+++ b/src/cli/commands/__integration__/doctor.test.ts
@@ -106,6 +106,24 @@ describe('CLI Integration: doctor', () => {
       expect(stdout).toContain('reskill version');
       expect(exitCode).toBeLessThanOrEqual(1);
     });
+
+    it('should check registry auth status', () => {
+      const { stdout, exitCode } = runCli('doctor --skip-network', tempDir);
+      expect(stdout).toContain('Registry auth');
+      expect(exitCode).toBeLessThanOrEqual(1);
+    });
+
+    it('should check environment variables', () => {
+      const { stdout, exitCode } = runCli('doctor --skip-network', tempDir);
+      expect(stdout).toContain('Environment vars');
+      expect(exitCode).toBeLessThanOrEqual(1);
+    });
+
+    it('should check detected agents', () => {
+      const { stdout, exitCode } = runCli('doctor --skip-network', tempDir);
+      expect(stdout).toContain('Detected agents');
+      expect(exitCode).toBeLessThanOrEqual(1);
+    });
   });
 
   describe('configuration checks', () => {
@@ -282,6 +300,54 @@ description: Test skill
       expect(exitCode).toBe(1);
     });
 
+    it('should error on invalid installMode', () => {
+      fs.writeFileSync(
+        path.join(tempDir, 'skills.json'),
+        JSON.stringify({
+          skills: {},
+          defaults: {
+            installMode: 'invalid-mode',
+          },
+        }),
+      );
+
+      const { stdout, exitCode } = runCli('doctor --skip-network', tempDir);
+      expect(stdout).toContain('Invalid installMode');
+      expect(exitCode).toBe(1);
+    });
+
+    it('should warn on invalid publishRegistry URL', () => {
+      fs.writeFileSync(
+        path.join(tempDir, 'skills.json'),
+        JSON.stringify({
+          skills: {},
+          defaults: {
+            publishRegistry: 'not-a-url',
+          },
+        }),
+      );
+
+      const { stdout, exitCode } = runCli('doctor --skip-network', tempDir);
+      expect(stdout).toContain('Invalid publishRegistry');
+      expect(exitCode).toBeLessThanOrEqual(1);
+    });
+
+    it('should error on invalid registry URL format', () => {
+      fs.writeFileSync(
+        path.join(tempDir, 'skills.json'),
+        JSON.stringify({
+          skills: {},
+          registries: {
+            broken: 'not-a-url',
+          },
+        }),
+      );
+
+      const { stdout, exitCode } = runCli('doctor --skip-network', tempDir);
+      expect(stdout).toContain('Invalid registry URL');
+      expect(exitCode).toBe(1);
+    });
+
     it('should warn about monorepo version mismatch', () => {
       fs.writeFileSync(
         path.join(tempDir, 'skills.json'),
@@ -347,9 +413,12 @@ description: Test skill
       expect(checkNames).toContain('reskill version');
       expect(checkNames).toContain('Node.js version');
       expect(checkNames).toContain('Git');
+      expect(checkNames).toContain('Registry auth');
+      expect(checkNames).toContain('Environment vars');
       expect(checkNames).toContain('skills.json');
       expect(checkNames).toContain('skills.lock');
       expect(checkNames).toContain('Installed skills');
+      expect(checkNames).toContain('Detected agents');
     });
 
     it('should include hints in JSON output for issues', () => {

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -5,14 +5,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type CheckResult,
   type CheckStatus,
+  checkAuthStatus,
   checkCacheDir,
+  checkDetectedAgents,
+  checkEnvVars,
   checkGitAuth,
   checkGitVersion,
   checkInstallDir,
+  checkInstallMode,
   checkInstalledSkills,
   checkMonorepoVersions,
   checkNetwork,
   checkNodeVersion,
+  checkPublishRegistry,
   checkRegistryConflicts,
   checkReskillVersion,
   checkSkillRefs,
@@ -22,6 +27,7 @@ import {
   countCachedSkills,
   execCommand,
   formatBytes,
+  getCustomRegistryUrls,
   getDirSize,
   getStatusIcon,
   printResult,
@@ -229,6 +235,95 @@ describe('doctor checks', () => {
     });
   });
 
+  describe('checkAuthStatus', () => {
+    let savedToken: string | undefined;
+
+    beforeEach(() => {
+      savedToken = process.env.RESKILL_TOKEN;
+    });
+
+    afterEach(() => {
+      if (savedToken !== undefined) {
+        process.env.RESKILL_TOKEN = savedToken;
+      } else {
+        delete process.env.RESKILL_TOKEN;
+      }
+    });
+
+    it('should return ok when RESKILL_TOKEN is set', () => {
+      process.env.RESKILL_TOKEN = 'test-token-123';
+      const result = checkAuthStatus();
+      expect(result.name).toBe('Registry auth');
+      expect(result.status).toBe('ok');
+      expect(result.message).toContain('RESKILL_TOKEN');
+    });
+
+    it('should return a valid check result', () => {
+      delete process.env.RESKILL_TOKEN;
+      const result = checkAuthStatus();
+      expect(result.name).toBe('Registry auth');
+      expect(['ok', 'warn']).toContain(result.status);
+    });
+  });
+
+  describe('checkEnvVars', () => {
+    let savedToken: string | undefined;
+    let savedRegistry: string | undefined;
+    let savedCacheDir: string | undefined;
+
+    beforeEach(() => {
+      savedToken = process.env.RESKILL_TOKEN;
+      savedRegistry = process.env.RESKILL_REGISTRY;
+      savedCacheDir = process.env.RESKILL_CACHE_DIR;
+    });
+
+    afterEach(() => {
+      if (savedToken !== undefined) {
+        process.env.RESKILL_TOKEN = savedToken;
+      } else {
+        delete process.env.RESKILL_TOKEN;
+      }
+      if (savedRegistry !== undefined) {
+        process.env.RESKILL_REGISTRY = savedRegistry;
+      } else {
+        delete process.env.RESKILL_REGISTRY;
+      }
+      if (savedCacheDir !== undefined) {
+        process.env.RESKILL_CACHE_DIR = savedCacheDir;
+      } else {
+        delete process.env.RESKILL_CACHE_DIR;
+      }
+    });
+
+    it('should return ok with "none set" when no env vars', () => {
+      delete process.env.RESKILL_TOKEN;
+      delete process.env.RESKILL_REGISTRY;
+      delete process.env.RESKILL_CACHE_DIR;
+      const result = checkEnvVars();
+      expect(result.name).toBe('Environment vars');
+      expect(result.status).toBe('ok');
+      expect(result.message).toBe('none set');
+    });
+
+    it('should list set env vars', () => {
+      process.env.RESKILL_REGISTRY = 'https://example.com';
+      delete process.env.RESKILL_TOKEN;
+      delete process.env.RESKILL_CACHE_DIR;
+      const result = checkEnvVars();
+      expect(result.status).toBe('ok');
+      expect(result.message).toContain('RESKILL_REGISTRY');
+    });
+
+    it('should list multiple env vars', () => {
+      process.env.RESKILL_TOKEN = 'tok';
+      process.env.RESKILL_REGISTRY = 'https://example.com';
+      delete process.env.RESKILL_CACHE_DIR;
+      const result = checkEnvVars();
+      expect(result.message).toContain('RESKILL_TOKEN');
+      expect(result.message).toContain('RESKILL_REGISTRY');
+    });
+  });
+
   describe('checkSkillsJson', () => {
     let testDir: string;
 
@@ -391,6 +486,37 @@ describe('doctor checks', () => {
       expect(result.status).toBe('warn');
       expect(result.message).toContain('out of sync');
       expect(result.message).toContain('missing');
+    });
+
+    it('should return warn when lockfileVersion is unsupported', () => {
+      writeFileSync(
+        join(testDir, 'skills.json'),
+        JSON.stringify({
+          skills: {
+            'test-skill': 'github:user/repo@v1.0.0',
+          },
+        }),
+      );
+      writeFileSync(
+        join(testDir, 'skills.lock'),
+        JSON.stringify({
+          lockfileVersion: 999,
+          skills: {
+            'test-skill': {
+              source: 'github:user/repo',
+              version: 'v1.0.0',
+              ref: 'v1.0.0',
+              resolved: 'https://github.com/user/repo',
+              commit: 'abc123',
+              installedAt: new Date().toISOString(),
+            },
+          },
+        }),
+      );
+      const result = checkSkillsLock(testDir);
+      expect(result.status).toBe('warn');
+      expect(result.message).toContain('unsupported lockfile version');
+      expect(result.message).toContain('999');
     });
 
     it('should return warn when skills.lock has extra skills', () => {
@@ -701,6 +827,39 @@ describe('checkRegistryConflicts', () => {
     const results = checkRegistryConflicts(testDir);
     expect(results).toEqual([]);
   });
+
+  it('should error for invalid registry URL format', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        registries: {
+          broken: 'not-a-valid-url',
+        },
+      }),
+    );
+    const results = checkRegistryConflicts(testDir);
+    expect(results.length).toBe(1);
+    expect(results[0].status).toBe('error');
+    expect(results[0].name).toBe('Invalid registry URL');
+    expect(results[0].message).toContain('broken');
+  });
+
+  it('should report both conflict and invalid URL', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        registries: {
+          github: 'not-a-url',
+        },
+      }),
+    );
+    const results = checkRegistryConflicts(testDir);
+    expect(results.length).toBe(2);
+    expect(results.some((r) => r.name === 'Registry conflict')).toBe(true);
+    expect(results.some((r) => r.name === 'Invalid registry URL')).toBe(true);
+  });
 });
 
 describe('checkInstallDir', () => {
@@ -779,6 +938,225 @@ describe('checkInstallDir', () => {
     expect(result).not.toBeNull();
     expect(result?.status).toBe('error');
     expect(result?.message).toContain('path traversal');
+  });
+});
+
+describe('checkInstallMode', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `doctor-installmode-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should return null when no skills.json exists', () => {
+    const result = checkInstallMode(testDir);
+    expect(result).toBeNull();
+  });
+
+  it('should return null when no installMode is set', () => {
+    writeFileSync(join(testDir, 'skills.json'), JSON.stringify({ skills: {} }));
+    const result = checkInstallMode(testDir);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for valid installMode "symlink"', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        defaults: { installMode: 'symlink' },
+      }),
+    );
+    const result = checkInstallMode(testDir);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for valid installMode "copy"', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        defaults: { installMode: 'copy' },
+      }),
+    );
+    const result = checkInstallMode(testDir);
+    expect(result).toBeNull();
+  });
+
+  it('should error for invalid installMode', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        defaults: { installMode: 'link' },
+      }),
+    );
+    const result = checkInstallMode(testDir);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe('error');
+    expect(result?.message).toContain('link');
+    expect(result?.hint).toContain('symlink');
+    expect(result?.hint).toContain('copy');
+  });
+});
+
+describe('checkPublishRegistry', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `doctor-pubreg-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should return null when no skills.json exists', () => {
+    const result = checkPublishRegistry(testDir);
+    expect(result).toBeNull();
+  });
+
+  it('should return null when no publishRegistry is set', () => {
+    writeFileSync(join(testDir, 'skills.json'), JSON.stringify({ skills: {} }));
+    const result = checkPublishRegistry(testDir);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for valid https publishRegistry', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        defaults: { publishRegistry: 'https://registry.example.com' },
+      }),
+    );
+    const result = checkPublishRegistry(testDir);
+    expect(result).toBeNull();
+  });
+
+  it('should warn for invalid publishRegistry URL', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        defaults: { publishRegistry: 'not-a-url' },
+      }),
+    );
+    const result = checkPublishRegistry(testDir);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe('warn');
+    expect(result?.message).toContain('not-a-url');
+  });
+});
+
+describe('checkDetectedAgents', () => {
+  it('should return a valid check result', async () => {
+    const result = await checkDetectedAgents();
+    expect(result.name).toBe('Detected agents');
+    expect(result.status).toBe('ok');
+    // Should contain either "none detected" or "N detected: ..."
+    expect(result.message).toMatch(/detected/);
+  });
+});
+
+describe('getCustomRegistryUrls', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `doctor-customreg-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should return empty array when no skills.json exists', () => {
+    const urls = getCustomRegistryUrls(testDir);
+    expect(urls).toEqual([]);
+  });
+
+  it('should return empty array when only built-in registries', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        registries: {
+          github: 'https://github.com',
+          gitlab: 'https://gitlab.com',
+        },
+      }),
+    );
+    const urls = getCustomRegistryUrls(testDir);
+    expect(urls).toEqual([]);
+  });
+
+  it('should return custom registry URLs', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        registries: {
+          internal: 'https://gitlab.company.com',
+        },
+      }),
+    );
+    const urls = getCustomRegistryUrls(testDir);
+    expect(urls).toEqual(['https://gitlab.company.com']);
+  });
+
+  it('should include publishRegistry', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        defaults: { publishRegistry: 'https://my-registry.com' },
+      }),
+    );
+    const urls = getCustomRegistryUrls(testDir);
+    expect(urls).toContain('https://my-registry.com');
+  });
+
+  it('should deduplicate URLs', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        registries: {
+          internal: 'https://my-registry.com',
+        },
+        defaults: { publishRegistry: 'https://my-registry.com' },
+      }),
+    );
+    const urls = getCustomRegistryUrls(testDir);
+    expect(urls.length).toBe(1);
+  });
+
+  it('should skip invalid URLs', () => {
+    writeFileSync(
+      join(testDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        registries: {
+          broken: 'not-a-url',
+          valid: 'https://valid.example.com',
+        },
+      }),
+    );
+    const urls = getCustomRegistryUrls(testDir);
+    expect(urls).toEqual(['https://valid.example.com']);
   });
 });
 
@@ -1120,18 +1498,21 @@ describe('runDoctorChecks', () => {
       skipConfigChecks: true,
     });
 
-    // Should have 8 basic checks when network and config checks are skipped
-    expect(results.length).toBe(8);
+    // Should have 11 basic checks when network and config checks are skipped
+    expect(results.length).toBe(11);
 
     const checkNames = results.map((r) => r.name);
     expect(checkNames).toContain('reskill version');
     expect(checkNames).toContain('Node.js version');
     expect(checkNames).toContain('Git');
     expect(checkNames).toContain('Git authentication');
+    expect(checkNames).toContain('Registry auth');
+    expect(checkNames).toContain('Environment vars');
     expect(checkNames).toContain('Cache directory');
     expect(checkNames).toContain('skills.json');
     expect(checkNames).toContain('skills.lock');
     expect(checkNames).toContain('Installed skills');
+    expect(checkNames).toContain('Detected agents');
   });
 
   it(
@@ -1145,8 +1526,8 @@ describe('runDoctorChecks', () => {
         skipConfigChecks: true,
       });
 
-      // Should have 10 checks with network
-      expect(results.length).toBe(10);
+      // Should have 13 checks with network
+      expect(results.length).toBe(13);
 
       const checkNames = results.map((r) => r.name);
       expect(checkNames.some((n) => n.includes('github.com'))).toBe(true);

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -5,8 +5,9 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { isValidAgentType } from '../../core/agent-registry.js';
-import { ConfigLoader } from '../../core/config-loader.js';
+import { detectInstalledAgents, isValidAgentType } from '../../core/agent-registry.js';
+import { AuthManager } from '../../core/auth-manager.js';
+import { ConfigLoader, DEFAULT_REGISTRIES } from '../../core/config-loader.js';
 import { GitResolver } from '../../core/git-resolver.js';
 import { HttpResolver } from '../../core/http-resolver.js';
 import { LockManager } from '../../core/lock-manager.js';
@@ -257,6 +258,98 @@ export function checkGitAuth(): CheckResult {
 }
 
 /**
+ * Valid install modes
+ *
+ * Must stay in sync with InstallMode type from installer.ts ('symlink' | 'copy').
+ * TypeScript literal union types are erased at runtime, so we maintain this list manually.
+ */
+const VALID_INSTALL_MODES = ['symlink', 'copy'];
+
+/**
+ * Check registry authentication status
+ *
+ * Verifies actual token availability, not just file existence.
+ * Uses AuthManager.getToken() which checks RESKILL_TOKEN env first,
+ * then reads ~/.reskillrc for the configured registry.
+ */
+export function checkAuthStatus(): CheckResult {
+  const hasEnvToken = !!process.env.RESKILL_TOKEN;
+
+  if (hasEnvToken) {
+    return {
+      name: 'Registry auth',
+      status: 'ok',
+      message: 'RESKILL_TOKEN set',
+    };
+  }
+
+  // Check if ~/.reskillrc has any valid tokens
+  const authManager = new AuthManager();
+  const configPath = authManager.getConfigPath();
+
+  if (!existsSync(configPath)) {
+    return {
+      name: 'Registry auth',
+      status: 'warn',
+      message: 'no token configured',
+      hint: 'Run: reskill login (needed for publish and private skills)',
+    };
+  }
+
+  // File exists — check if it actually contains a token for any registry
+  const hasToken = authManager.hasToken();
+  if (hasToken) {
+    return {
+      name: 'Registry auth',
+      status: 'ok',
+      message: 'token configured via ~/.reskillrc',
+    };
+  }
+
+  return {
+    name: 'Registry auth',
+    status: 'warn',
+    message: '~/.reskillrc exists but no token found for current registry',
+    hint: 'Run: reskill login (needed for publish and private skills)',
+  };
+}
+
+/**
+ * Check environment variables used by reskill
+ *
+ * Security: Only report variable names, never values.
+ * RESKILL_TOKEN contains a secret and must not be displayed.
+ */
+export function checkEnvVars(): CheckResult {
+  // Only collect names, never values (RESKILL_TOKEN is a secret)
+  const vars: string[] = [];
+
+  if (process.env.RESKILL_TOKEN) {
+    vars.push('RESKILL_TOKEN');
+  }
+  if (process.env.RESKILL_REGISTRY) {
+    vars.push('RESKILL_REGISTRY');
+  }
+  if (process.env.RESKILL_CACHE_DIR) {
+    vars.push('RESKILL_CACHE_DIR');
+  }
+
+  if (vars.length === 0) {
+    return {
+      name: 'Environment vars',
+      status: 'ok',
+      message: 'none set',
+    };
+  }
+
+  return {
+    name: 'Environment vars',
+    status: 'ok',
+    message: `${vars.join(', ')} set`,
+  };
+}
+
+/**
  * Check cache directory
  */
 export function checkCacheDir(): CheckResult {
@@ -366,13 +459,23 @@ export function checkRegistryConflicts(cwd: string): CheckResult[] {
     const config = configLoader.load();
     const registries = config.registries || {};
 
-    for (const name of Object.keys(registries)) {
+    for (const [name, url] of Object.entries(registries)) {
       if (RESERVED_REGISTRIES.includes(name.toLowerCase())) {
         results.push({
           name: 'Registry conflict',
           status: 'warn',
           message: `"${name}" overrides built-in registry`,
           hint: 'Consider using a different name for custom registries',
+        });
+      }
+
+      // Validate URL format
+      if (typeof url === 'string' && !/^https?:\/\//.test(url)) {
+        results.push({
+          name: 'Invalid registry URL',
+          status: 'error',
+          message: `"${name}": "${url}" is not a valid URL`,
+          hint: 'Registry URLs must start with http:// or https://',
         });
       }
     }
@@ -419,6 +522,72 @@ export function checkInstallDir(cwd: string): CheckResult | null {
         status: 'error',
         message: `"${installDir}" contains path traversal`,
         hint: 'Use a simple directory name without ".."',
+      };
+    }
+  } catch {
+    // Ignore parse errors
+  }
+
+  return null;
+}
+
+/**
+ * Check for invalid installMode configuration
+ */
+export function checkInstallMode(cwd: string): CheckResult | null {
+  const configLoader = new ConfigLoader(cwd);
+
+  if (!configLoader.exists()) {
+    return null;
+  }
+
+  try {
+    const defaults = configLoader.getDefaults();
+    const installMode = defaults.installMode;
+
+    if (!installMode) {
+      return null;
+    }
+
+    if (!VALID_INSTALL_MODES.includes(installMode)) {
+      return {
+        name: 'Invalid installMode',
+        status: 'error',
+        message: `"${installMode}" is not a valid install mode`,
+        hint: 'Valid values: symlink, copy',
+      };
+    }
+  } catch {
+    // Ignore parse errors
+  }
+
+  return null;
+}
+
+/**
+ * Check for invalid publishRegistry configuration
+ */
+export function checkPublishRegistry(cwd: string): CheckResult | null {
+  const configLoader = new ConfigLoader(cwd);
+
+  if (!configLoader.exists()) {
+    return null;
+  }
+
+  try {
+    const defaults = configLoader.getDefaults();
+    const publishRegistry = defaults.publishRegistry;
+
+    if (!publishRegistry) {
+      return null;
+    }
+
+    if (!/^https?:\/\//.test(publishRegistry)) {
+      return {
+        name: 'Invalid publishRegistry',
+        status: 'warn',
+        message: `"${publishRegistry}" is not a valid URL`,
+        hint: 'publishRegistry must start with http:// or https://',
       };
     }
   } catch {
@@ -620,6 +789,18 @@ export function checkSkillsLock(cwd: string): CheckResult {
     };
   }
 
+  // Check lockfile version compatibility before sync check
+  // If version is unsupported, sync results would be meaningless
+  const lockData = lockManager.load();
+  if (lockData.lockfileVersion !== 1) {
+    return {
+      name: 'skills.lock',
+      status: 'warn',
+      message: `unsupported lockfile version: ${lockData.lockfileVersion}`,
+      hint: 'Run: reskill install to regenerate',
+    };
+  }
+
   // Check if lock is in sync with config
   const configSkills = configLoader.getSkills();
   const lockedSkills = lockManager.getAll();
@@ -772,6 +953,92 @@ export function checkInstalledSkills(cwd: string): CheckResult[] {
 }
 
 /**
+ * Check detected agents
+ */
+export async function checkDetectedAgents(): Promise<CheckResult> {
+  try {
+    const installed = await detectInstalledAgents();
+
+    if (installed.length === 0) {
+      return {
+        name: 'Detected agents',
+        status: 'ok',
+        message: 'none detected',
+      };
+    }
+
+    return {
+      name: 'Detected agents',
+      status: 'ok',
+      message: `${installed.length} detected: ${installed.join(', ')}`,
+    };
+  } catch {
+    return {
+      name: 'Detected agents',
+      status: 'warn',
+      message: 'detection failed',
+    };
+  }
+}
+
+/**
+ * Get custom registry URLs for network checks
+ *
+ * Reads registries from skills.json and publishRegistry,
+ * excluding built-in github.com/gitlab.com and deduplicating.
+ */
+/**
+ * Normalize a URL to its origin for comparison.
+ * Handles trailing slashes and case differences (e.g., GITHUB.COM → github.com).
+ */
+function normalizeUrlOrigin(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return url;
+  }
+}
+
+export function getCustomRegistryUrls(cwd: string): string[] {
+  const urls = new Set<string>();
+  const builtinOrigins = new Set(
+    Object.values(DEFAULT_REGISTRIES).map((u) => normalizeUrlOrigin(u)),
+  );
+
+  try {
+    const configLoader = new ConfigLoader(cwd);
+    if (!configLoader.exists()) {
+      return [];
+    }
+
+    // Collect custom registry URLs
+    const config = configLoader.load();
+    const registries = config.registries || {};
+    for (const url of Object.values(registries)) {
+      if (
+        typeof url === 'string' &&
+        /^https?:\/\//.test(url) &&
+        !builtinOrigins.has(normalizeUrlOrigin(url))
+      ) {
+        urls.add(url);
+      }
+    }
+
+    // Collect publishRegistry
+    const defaults = configLoader.getDefaults();
+    if (defaults.publishRegistry && /^https?:\/\//.test(defaults.publishRegistry)) {
+      if (!builtinOrigins.has(normalizeUrlOrigin(defaults.publishRegistry))) {
+        urls.add(defaults.publishRegistry);
+      }
+    }
+  } catch {
+    // Ignore errors
+  }
+
+  return [...urls];
+}
+
+/**
  * Check network connectivity
  */
 export async function checkNetwork(host: string): Promise<CheckResult> {
@@ -840,27 +1107,42 @@ export async function runDoctorChecks(options: {
   const { cwd, packageName, packageVersion, skipNetwork, skipConfigChecks } = options;
   const results: CheckResult[] = [];
 
-  // Version checks
+  // Environment checks
   results.push(await checkReskillVersion(packageVersion, packageName));
   results.push(checkNodeVersion());
   results.push(checkGitVersion());
   results.push(checkGitAuth());
+  results.push(checkAuthStatus());
+  results.push(checkEnvVars());
 
   // Directory checks
   results.push(checkCacheDir());
   results.push(checkSkillsJson(cwd));
   results.push(checkSkillsLock(cwd));
   results.push(...checkInstalledSkills(cwd));
+  results.push(await checkDetectedAgents());
 
   // Deep config checks (can be skipped for faster checks)
   if (!skipConfigChecks) {
-    // Registry conflicts
+    // Registry conflicts + URL validation
     results.push(...checkRegistryConflicts(cwd));
 
     // installDir validation
     const installDirCheck = checkInstallDir(cwd);
     if (installDirCheck) {
       results.push(installDirCheck);
+    }
+
+    // installMode validation
+    const installModeCheck = checkInstallMode(cwd);
+    if (installModeCheck) {
+      results.push(installModeCheck);
+    }
+
+    // publishRegistry validation
+    const publishRegistryCheck = checkPublishRegistry(cwd);
+    if (publishRegistryCheck) {
+      results.push(publishRegistryCheck);
     }
 
     // targetAgents validation
@@ -877,6 +1159,12 @@ export async function runDoctorChecks(options: {
   if (!skipNetwork) {
     results.push(await checkNetwork('https://github.com'));
     results.push(await checkNetwork('https://gitlab.com'));
+
+    // Custom registry connectivity
+    const customUrls = getCustomRegistryUrls(cwd);
+    for (const url of customUrls) {
+      results.push(await checkNetwork(url));
+    }
   }
 
   return results;


### PR DESCRIPTION
Previously `reskill doctor` could report all-green while `install`, `publish`, or `find` would fail at runtime due to unchecked config or auth issues.

New checks:
- Registry auth: verify token via ~/.reskillrc or RESKILL_TOKEN
- Environment vars: report active RESKILL_* env vars (names only)
- Detected agents: surface detectInstalledAgents() results
- installMode validation: reject values other than symlink/copy
- publishRegistry validation: verify URL format
- Registry URL format: error on non-http(s) custom registry URLs
- Custom registry network: connectivity check for custom registries
- lockfileVersion: validate before sync check (order fix)

Also addressed code review feedback:
- checkAuthStatus verifies actual token, not just file existence
- checkDetectedAgents catch returns warn instead of ok
- getCustomRegistryUrls normalizes URLs via origin for comparison
- Test env cleanup uses per-key save/restore instead of object replacement
- Added security comments for RESKILL_TOKEN handling