### PR TITLE
docs(readme): sync CLI docs for group and related options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,40 +46,66 @@ npx reskill@latest <command>  # Or use npx directly
 | Command               | Alias                | Description                               |
 | --------------------- | -------------------- | ----------------------------------------- |
 | `init`                | -                    | Initialize `skills.json`                  |
-| `find <query>`        | -                    | Search for skills in the registry         |
+| `find <query>`        | `search`             | Search for skills in the registry         |
 | `install [skills...]` | `i`                  | Install one or more skills                |
 | `list`                | `ls`                 | List installed skills                     |
 | `info <skill>`        | -                    | Show skill details                        |
 | `update [skill]`      | `up`                 | Update skills                             |
 | `outdated`            | -                    | Check for outdated skills                 |
 | `uninstall <skill>`   | `un`, `rm`, `remove` | Remove a skill                            |
+| `group`               | -                    | Manage skill groups ¹                     |
 | `publish [path]`      | `pub`                | Publish a skill to the registry ¹         |
 | `login`               | -                    | Authenticate with the registry ¹          |
 | `logout`              | -                    | Remove stored authentication ¹            |
 | `whoami`              | -                    | Display current logged in user ¹          |
 | `doctor`              | -                    | Diagnose environment and check for issues |
-| `completion install`  | -                    | Install shell tab completion              |
+| `completion [action]` | -                    | Setup or remove shell tab completion      |
 
-> ¹ Registry commands (`publish`, `login`, `logout`, `whoami`) require a private registry deployment. Not available for public use yet.
+> ¹ Registry commands (`group`, `publish`, `login`, `logout`, `whoami`) require a private registry deployment. Not available for public use yet.
 
 ### Common Options
 
-| Option                    | Commands                             | Description                                                   |
-| ------------------------- | ------------------------------------ | ------------------------------------------------------------- |
-| `--no-save`               | `install`                            | Install without saving to `skills.json` (for personal skills) |
-| `-g, --global`            | `install`, `uninstall`, `list`       | Install/manage skills globally (user directory)               |
-| `-a, --agent <agents...>` | `install`                            | Specify target agents (e.g., `cursor`, `claude-code`)         |
-| `--mode <mode>`           | `install`                            | Installation mode: `symlink` (default) or `copy`              |
-| `--all`                   | `install`                            | Install to all agents                                         |
-| `-y, --yes`               | `install`, `uninstall`, `publish`    | Skip confirmation prompts                                     |
-| `-f, --force`             | `install`                            | Force reinstall even if already installed                     |
-| `-s, --skill <names...>`  | `install`                            | Select specific skill(s) by name from a multi-skill repo      |
-| `--list`                  | `install`                            | List available skills in the repository without installing    |
-| `-r, --registry <url>`    | `install`, `publish`                 | Registry URL override for registry-based installs             |
-| `-t, --token <token>`     | `install`                            | Auth token for registry API requests (for CI/CD)              |
-| `-j, --json`              | `list`, `info`, `outdated`, `doctor` | Output as JSON                                                |
+| Option                    | Commands                                      | Description                                                   |
+| ------------------------- | --------------------------------------------- | ------------------------------------------------------------- |
+| `--no-save`               | `install`                                     | Install without saving to `skills.json` (for personal skills) |
+| `-g, --global`            | `install`, `uninstall`, `list`                | Install/manage skills globally (user directory)               |
+| `-a, --agent <agents...>` | `install`                                     | Specify target agents (e.g., `cursor`, `claude-code`)        |
+| `--mode <mode>`           | `install`                                     | Installation mode: `symlink` (default) or `copy`             |
+| `--all`                   | `install`                                     | Install to all agents                                         |
+| `-y, --yes`               | `install`, `uninstall`, `publish`             | Skip confirmation prompts                                     |
+| `-f, --force`             | `install`                                     | Force reinstall even if already installed                     |
+| `-s, --skill <names...>`  | `install`                                     | Select specific skill(s) by name from a multi-skill repo     |
+| `--list`                  | `install`                                     | List available skills in the repository without installing    |
+| `-t, --token <token>`     | `install`                                     | Auth token for registry API requests (for CI/CD)             |
+| `-r, --registry <url>`    | `install`, `group`, `publish`                 | Registry URL override for registry-enabled commands           |
+| `-j, --json`              | `list`, `info`, `outdated`, `doctor`, `group` | Output as JSON                                                |
+| `-l, --limit <n>`         | `find`                                        | Maximum number of search results                              |
+| `--skip-network`          | `doctor`                                      | Skip network connectivity checks                              |
 
 Run `reskill <command> --help` for complete options and detailed usage.
+
+### Group Command Quick Reference
+
+```bash
+# List groups
+reskill group list
+reskill group list --tree
+
+# Create / inspect / delete groups
+reskill group create "Frontend Team" --description "Frontend skills"
+reskill group info kanyun/frontend
+reskill group delete kanyun/frontend --dry-run
+reskill group delete kanyun/frontend -y
+
+# Manage members
+reskill group member list kanyun/frontend
+reskill group member add kanyun/frontend alice bob --role developer
+reskill group member remove kanyun/frontend alice
+reskill group member role kanyun/frontend bob maintainer
+```
+
+`publish --group <path>` normalizes and validates the path before request.  
+For full group path rules, see [CLI Specification - group](./docs/cli-spec.md#group).
 
 ## Source Formats
 
@@ -212,6 +238,13 @@ Skills are installed to `.skills/` by default and can be integrated with any age
 Publish your skills to the registry for others to use:
 
 ```bash
+# Group management examples
+reskill group list
+reskill group list --tree
+reskill group create "Frontend Team" --description "Frontend skills"
+reskill group info kanyun/frontend
+reskill group member add kanyun/frontend alice bob --role developer
+
 # Interactive login (recommended for humans — guides you through token setup)
 reskill login
 
@@ -220,6 +253,9 @@ reskill login --token <your-token>
 
 # Validate without publishing (dry run)
 reskill publish --dry-run
+
+# Validate publish with target group
+reskill publish --dry-run --group kanyun/frontend
 
 # Publish the skill
 reskill publish
@@ -250,7 +286,10 @@ reskill install @scope/private-skill --registry https://your-registry.com --toke
 | `RESKILL_TOKEN`     | Auth token (takes precedence over ~/.reskillrc) | -                              |
 | `RESKILL_REGISTRY`  | Default registry URL                            | `https://registry.reskill.dev` |
 | `DEBUG`             | Enable debug logging                            | -                              |
+| `VERBOSE`           | Enable debug logging (same effect as `DEBUG`)   | -                              |
 | `NO_COLOR`          | Disable colored output                          | -                              |
+
+reskill checks for newer versions in the background and shows an upgrade tip after command execution.
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,40 +46,66 @@ npx reskill@latest <command>  # 或直接使用 npx
 | 命令                  | 别名                 | 说明                      |
 | --------------------- | -------------------- | ------------------------- |
 | `init`                | -                    | 初始化 `skills.json`      |
-| `find <query>`        | -                    | 在 registry 中搜索 skills |
+| `find <query>`        | `search`             | 在 registry 中搜索 skills |
 | `install [skills...]` | `i`                  | 安装一个或多个 skills     |
 | `list`                | `ls`                 | 列出已安装的 skills       |
 | `info <skill>`        | -                    | 查看 skill 详情           |
 | `update [skill]`      | `up`                 | 更新 skills               |
 | `outdated`            | -                    | 检查过期的 skills         |
 | `uninstall <skill>`   | `un`, `rm`, `remove` | 卸载 skill                |
+| `group`               | -                    | 管理 skill 分组 ¹         |
 | `publish [path]`      | `pub`                | 发布 skill 到 registry ¹  |
 | `login`               | -                    | 登录 registry ¹           |
 | `logout`              | -                    | 登出 registry ¹           |
 | `whoami`              | -                    | 显示当前登录用户 ¹        |
 | `doctor`              | -                    | 诊断环境并检查问题        |
-| `completion install`  | -                    | 安装 Shell Tab 补全       |
+| `completion [action]` | -                    | 配置或移除 Shell Tab 补全 |
 
-> ¹ Registry 相关命令（`publish`、`login`、`logout`、`whoami`）需要部署私有 registry 后才能使用，暂不对外开放。
+> ¹ Registry 相关命令（`group`、`publish`、`login`、`logout`、`whoami`）需要部署私有 registry 后才能使用，暂不对外开放。
 
 ### 常用选项
 
-| 选项                      | 适用命令                             | 说明                                         |
-| ------------------------- | ------------------------------------ | -------------------------------------------- |
-| `--no-save`               | `install`                            | 安装时不保存到 `skills.json`（用于个人技能） |
-| `-g, --global`            | `install`, `uninstall`, `list`       | 全局安装/管理技能（用户目录）                |
-| `-a, --agent <agents...>` | `install`                            | 指定目标 Agent（如 `cursor`, `claude-code`） |
-| `--mode <mode>`           | `install`                            | 安装模式：`symlink`（默认）或 `copy`         |
-| `--all`                   | `install`                            | 安装到所有 Agent                             |
-| `-y, --yes`               | `install`, `uninstall`, `publish`    | 跳过确认提示                                 |
-| `-f, --force`             | `install`                            | 强制重新安装                                 |
-| `-s, --skill <names...>`  | `install`                            | 从多 skill 仓库中选择指定 skill              |
-| `--list`                  | `install`                            | 列出仓库中可用的 skills（不安装）            |
-| `-r, --registry <url>`    | `install`, `publish`                 | 覆盖 registry URL（用于 registry 安装）      |
-| `-t, --token <token>`     | `install`                            | 认证令牌（用于 CI/CD 访问私有 skill）        |
-| `-j, --json`              | `list`, `info`, `outdated`, `doctor` | JSON 格式输出                                |
+| 选项                      | 适用命令                                      | 说明                                         |
+| ------------------------- | --------------------------------------------- | -------------------------------------------- |
+| `--no-save`               | `install`                                     | 安装时不保存到 `skills.json`（用于个人技能） |
+| `-g, --global`            | `install`, `uninstall`, `list`                | 全局安装/管理技能（用户目录）                |
+| `-a, --agent <agents...>` | `install`                                     | 指定目标 Agent（如 `cursor`, `claude-code`） |
+| `--mode <mode>`           | `install`                                     | 安装模式：`symlink`（默认）或 `copy`         |
+| `--all`                   | `install`                                     | 安装到所有 Agent                             |
+| `-y, --yes`               | `install`, `uninstall`, `publish`             | 跳过确认提示                                 |
+| `-f, --force`             | `install`                                     | 强制重新安装                                 |
+| `-s, --skill <names...>`  | `install`                                     | 从多 skill 仓库中选择指定 skill              |
+| `--list`                  | `install`                                     | 列出仓库中可用的 skills（不安装）            |
+| `-t, --token <token>`     | `install`                                     | 认证令牌（用于 CI/CD 访问私有 skill）        |
+| `-r, --registry <url>`    | `install`, `group`, `publish`                 | 覆盖 registry URL（用于 registry 相关命令）  |
+| `-j, --json`              | `list`, `info`, `outdated`, `doctor`, `group` | JSON 格式输出                                |
+| `-l, --limit <n>`         | `find`                                        | 限制搜索结果数量                             |
+| `--skip-network`          | `doctor`                                      | 跳过网络连通性检查                           |
 
 运行 `reskill <command> --help` 查看完整选项和详细用法。
+
+### Group 命令速查
+
+```bash
+# 查看分组
+reskill group list
+reskill group list --tree
+
+# 创建 / 查看 / 删除分组
+reskill group create "Frontend Team" --description "Frontend skills"
+reskill group info kanyun/frontend
+reskill group delete kanyun/frontend --dry-run
+reskill group delete kanyun/frontend -y
+
+# 成员管理
+reskill group member list kanyun/frontend
+reskill group member add kanyun/frontend alice bob --role developer
+reskill group member remove kanyun/frontend alice
+reskill group member role kanyun/frontend bob maintainer
+```
+
+`publish --group <path>` 在请求前会先做路径归一化和校验。  
+完整规则见 [CLI 规范 - group](./docs/cli-spec.md#group)。
 
 ## 源格式
 
@@ -212,11 +238,24 @@ Skills 默认安装到 `.skills/`，可与任何 Agent 集成：
 将你的 skills 发布到 registry 供他人使用：
 
 ```bash
-# 登录 registry
+# Group 管理示例
+reskill group list
+reskill group list --tree
+reskill group create "Frontend Team" --description "Frontend skills"
+reskill group info kanyun/frontend
+reskill group member add kanyun/frontend alice bob --role developer
+
+# 交互式登录（推荐日常使用）
 reskill login
+
+# 非交互式登录（CI/CD）
+reskill login --token <your-token>
 
 # 验证但不发布（预览模式）
 reskill publish --dry-run
+
+# 验证并指定目标分组
+reskill publish --dry-run --group kanyun/frontend
 
 # 发布 skill
 reskill publish
@@ -247,7 +286,10 @@ reskill install @scope/private-skill --registry https://your-registry.com --toke
 | `RESKILL_TOKEN`     | 认证令牌（优先于 ~/.reskillrc） | -                              |
 | `RESKILL_REGISTRY`  | 默认 registry URL               | `https://registry.reskill.dev` |
 | `DEBUG`             | 启用调试日志                    | -                              |
+| `VERBOSE`           | 启用调试日志（与 `DEBUG` 等效） | -                              |
 | `NO_COLOR`          | 禁用彩色输出                    | -                              |
+
+reskill 会在后台检查新版本，并在命令执行后提示升级信息。
 
 ## 开发
 


### PR DESCRIPTION
## Summary
- sync `README.md` and `README.zh-CN.md` with current CLI command surface, including `group` and `completion [action]`
- expand common options coverage to include `--registry`/`--json` updates plus `find --limit` and `doctor --skip-network`
- add bilingual quick references for `group` subcommands and `publish --group`, plus `VERBOSE` env var and update-notifier note

## Test plan
- [x] Manual doc consistency review against `src/cli/commands/*`
- [x] Verify bilingual README sections are aligned for the newly added command/option docs

Made with [Cursor](https://cursor.com)