### PR TITLE
fix(core): resolve scoped registries from skills.json config

### DIFF
--- a/.changeset/fix-scope-registry-from-config.md
+++ b/.changeset/fix-scope-registry-from-config.md
@@ -1,0 +1,19 @@
+---
+"reskill": patch
+---
+
+Fix scoped registry resolution to respect skills.json registries
+
+**Bug Fix:**
+- `resolveRegistryUrl` now reads `@scope`-prefixed entries from `skills.json` `registries` and passes them to `getRegistryUrl` as `customRegistries`
+- Previously, only the hardcoded `REGISTRY_SCOPE_MAP` was used for scope→registry resolution, ignoring user-configured scope mappings in `skills.json`
+- Custom scope registries in `skills.json` take priority over hardcoded defaults, with fallback to the hardcoded map for backward compatibility
+
+---
+
+修复 scoped registry 解析逻辑，使其读取 skills.json 中的 registries 配置
+
+**Bug 修复：**
+- `resolveRegistryUrl` 现在会从 `skills.json` 的 `registries` 中提取 `@scope` 开头的条目，作为 `customRegistries` 传递给 `getRegistryUrl`
+- 之前仅使用硬编码的 `REGISTRY_SCOPE_MAP` 进行 scope→registry 解析，忽略了用户在 `skills.json` 中配置的 scope 映射
+- `skills.json` 中的自定义 scope 配置优先于硬编码默认值，未配置时仍回退到硬编码映射，保持向后兼容

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -2500,6 +2500,54 @@ describe('SkillManager resolveRegistryUrl', () => {
     const url = await callResolveRegistryUrl(skillManager, 'unknown-skill');
     expect(url).toBe('https://reskill.info/');
   });
+
+  it('should use scoped registries from skills.json for scoped skills', async () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        registries: {
+          '@custom-scope': 'https://custom.registry.com/',
+        },
+      }),
+    );
+
+    const manager = new SkillManager(tempDir);
+    const url = await callResolveRegistryUrl(manager, '@custom-scope/my-skill');
+    expect(url).toBe('https://custom.registry.com/');
+  });
+
+  it('should allow skills.json scoped registries to override hardcoded defaults', async () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        registries: {
+          '@kanyun-test': 'https://override.registry.com/',
+        },
+      }),
+    );
+
+    const manager = new SkillManager(tempDir);
+    const url = await callResolveRegistryUrl(manager, '@kanyun-test/my-skill');
+    expect(url).toBe('https://override.registry.com/');
+  });
+
+  it('should still use hardcoded map when skills.json has no scoped entries', async () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'skills.json'),
+      JSON.stringify({
+        skills: {},
+        registries: {
+          github: 'https://github.com',
+        },
+      }),
+    );
+
+    const manager = new SkillManager(tempDir);
+    const url = await callResolveRegistryUrl(manager, '@kanyun/my-skill');
+    expect(url).toBe('https://rush.zhenguanyu.com/');
+  });
 });
 
 // ============================================================================

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -19,6 +19,7 @@ import {
 import { parseGitUrl } from '../utils/git.js';
 import { logger } from '../utils/logger.js';
 import {
+  type ScopeRegistries,
   getRegistryUrl,
   getScopeForRegistry,
   getShortName,
@@ -564,7 +565,7 @@ export class SkillManager {
    *
    * Resolution order:
    * 1. Explicit CLI override (options.registry)
-   * 2. Scoped skills → getRegistryUrl(scope)
+   * 2. Scoped skills → getRegistryUrl(scope, scopeRegistries from skills.json)
    * 3. Unscoped skills → lock file registry (O(1), no network)
    * 4. Unscoped skills → probe skills.json registries (non-git-host, network)
    * 5. Default → PUBLIC_REGISTRY
@@ -573,7 +574,10 @@ export class SkillManager {
     if (explicitRegistry) return explicitRegistry;
 
     const parsed = parseSkillIdentifier(ref);
-    if (parsed.scope) return getRegistryUrl(parsed.scope);
+    if (parsed.scope) {
+      const scopeRegistries = this.getScopeRegistriesFromConfig();
+      return getRegistryUrl(parsed.scope, scopeRegistries);
+    }
 
     // Fast path: lock file has registry URL
     const locked = this.lockManager.get(parsed.name);
@@ -607,6 +611,21 @@ export class SkillManager {
     const gitHostPatterns = ['github.com', 'gitlab.com'];
     const normalizedUrl = url.toLowerCase();
     return gitHostPatterns.some((pattern) => normalizedUrl.includes(pattern));
+  }
+
+  /**
+   * Extract @scope-prefixed entries from skills.json registries
+   * so users can configure custom scope→registry mappings declaratively.
+   */
+  private getScopeRegistriesFromConfig(): ScopeRegistries {
+    const registries = this.config.getRegistries();
+    const scopeRegistries: ScopeRegistries = {};
+    for (const [name, url] of Object.entries(registries)) {
+      if (name.startsWith('@')) {
+        scopeRegistries[name] = url;
+      }
+    }
+    return scopeRegistries;
   }
 
   /**


### PR DESCRIPTION
## Summary

- `resolveRegistryUrl` now reads `@scope`-prefixed entries from `skills.json` `registries` and passes them to `getRegistryUrl` as `customRegistries`
- Previously only the hardcoded `REGISTRY_SCOPE_MAP` was used for scope→registry resolution, ignoring user-configured scope mappings
- Custom scope registries in `skills.json` take priority over hardcoded defaults, with fallback for backward compatibility

## Changes

- `src/core/skill-manager.ts`: Added `getScopeRegistriesFromConfig()` method; updated `resolveRegistryUrl` to pass scope registries
- `src/core/skill-manager.test.ts`: 3 new tests covering custom scope, override, and fallback scenarios
- `.changeset/fix-scope-registry-from-config.md`: Patch changeset (bilingual)

## Test plan

- [x] Unit tests: 1461 passed
- [x] Integration tests: 237 passed
- [x] TypeScript typecheck: passed
- [x] Build: passed


Made with [Cursor](https://cursor.com)