### PR TITLE
fix: auto-detect repo default branch when version spec is absent

### DIFF
--- a/.changeset/fix-default-branch-detection.md
+++ b/.changeset/fix-default-branch-detection.md
@@ -1,0 +1,17 @@
+---
+"reskill": patch
+---
+
+Fix `install` failing on Git repositories whose default branch is not `main`.
+
+Previously, when a skill reference had no version spec (e.g. `@scope/my-skill` or `gitlab-host:owner/repo/subpath`), reskill hard-coded the clone ref to `main`. This broke installs on any repo whose real default branch was something else (most commonly `master` on self-hosted GitLab EE instances).
+
+Now the resolver introduces a new `'default'` version type. When no version spec is provided, reskill auto-detects the repository's actual default branch via `git ls-remote --symref <repoUrl> HEAD` (the same mechanism already used by `@latest` when no tags exist). Explicit `@branch:main` / `@main` (exact tag) references continue to work unchanged.
+
+---
+
+修复默认分支不是 `main` 的 Git 仓库无法 `install` 的问题。
+
+此前未指定版本（如 `@scope/my-skill` 或 `gitlab-host:owner/repo/subpath`）时，reskill 会把 clone 分支硬编码为 `main`，导致默认分支为其他名字的仓库（最常见的是自托管 GitLab EE 上的 `master` 仓库）无法安装。
+
+现在解析器新增 `'default'` 版本类型：未指定版本时通过 `git ls-remote --symref <repoUrl> HEAD` 自动探测仓库真实的默认分支（与 `@latest` 无 tag 时的回退机制一致）。显式指定 `@branch:main` / `@main`（精确 tag）的行为保持不变。

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -283,7 +283,7 @@ Skills can be installed directly from HTTP/HTTPS URLs pointing to archive files.
 | Range | `@^2.0.0` | Semver compatible (>=2.0.0 <3.0.0) |
 | Branch | `@branch:develop` | Specific branch |
 | Commit | `@commit:abc1234` | Specific commit hash |
-| (none) | - | Default branch (main) |
+| (none) | - | Repository default branch (auto-detected via `git ls-remote --symref HEAD`) |
 
 ---
 

--- a/src/core/git-resolver.test.ts
+++ b/src/core/git-resolver.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GitResolver } from './git-resolver.js';
+
+// Hoisted mock for git utils — allows resolveVersion tests to control
+// getDefaultBranch / getLatestTag without hitting a real Git remote.
+vi.mock('../utils/git.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/git.js')>();
+  return {
+    ...actual,
+    getDefaultBranch: vi.fn(),
+    getLatestTag: vi.fn(),
+    getRemoteTags: vi.fn(),
+  };
+});
+
+const gitUtils = await import('../utils/git.js');
+const mockGetDefaultBranch = vi.mocked(gitUtils.getDefaultBranch);
+const mockGetLatestTag = vi.mocked(gitUtils.getLatestTag);
 
 describe('GitResolver', () => {
   const resolver = new GitResolver('github');
@@ -141,10 +157,13 @@ describe('GitResolver', () => {
       });
     });
 
-    it('should default to branch:main for undefined', () => {
+    it('should use "default" type when version spec is undefined (repo default branch)', () => {
+      // Regression guard: previously returned { type: 'branch', value: 'main' },
+      // which broke installs for repos whose default branch is not 'main'
+      // (e.g. self-hosted GitLab EE with 'master' as default).
       expect(resolver.parseVersion(undefined)).toEqual({
-        type: 'branch',
-        value: 'main',
+        type: 'default',
+        value: '',
         raw: '',
       });
     });
@@ -602,10 +621,56 @@ describe('GitResolver', () => {
       expect(result.value).toBe('v1.0.0+build123');
     });
 
-    it('should treat empty string as default branch', () => {
+    it('should treat empty string as "default" type (repo default branch)', () => {
       const result = resolver.parseVersion('');
-      expect(result.type).toBe('branch');
-      expect(result.value).toBe('main');
+      expect(result.type).toBe('default');
+      expect(result.value).toBe('');
+    });
+  });
+
+  describe('resolveVersion — default branch auto-detection', () => {
+    beforeEach(() => {
+      mockGetDefaultBranch.mockReset();
+      mockGetLatestTag.mockReset();
+    });
+
+    it('should call getDefaultBranch when type is "default"', async () => {
+      // Regression: reskill used to hard-code clone ref to "main" when no version
+      // was specified, breaking repos whose default branch is "master".
+      mockGetDefaultBranch.mockResolvedValue('master');
+
+      const result = await resolver.resolveVersion('https://gitlab-ee.example.com/team/repo', {
+        type: 'default',
+        value: '',
+        raw: '',
+      });
+
+      expect(mockGetDefaultBranch).toHaveBeenCalledWith(
+        'https://gitlab-ee.example.com/team/repo',
+      );
+      expect(result).toEqual({ ref: 'master' });
+    });
+
+    it('should preserve explicit branch:main without auto-detection', async () => {
+      // Explicit branch:main must NOT be replaced by auto-detected default branch.
+      const result = await resolver.resolveVersion('https://example.com/owner/repo', {
+        type: 'branch',
+        value: 'main',
+        raw: 'branch:main',
+      });
+
+      expect(mockGetDefaultBranch).not.toHaveBeenCalled();
+      expect(result).toEqual({ ref: 'main' });
+    });
+
+    it('resolve() should end-to-end default to auto-detected branch when version is absent', async () => {
+      // Full resolve() path: "owner/repo" (no version) → default branch.
+      mockGetDefaultBranch.mockResolvedValue('develop');
+
+      const result = await resolver.resolve('user/skill');
+
+      expect(mockGetDefaultBranch).toHaveBeenCalledOnce();
+      expect(result.ref).toBe('develop');
     });
   });
 });

--- a/src/core/git-resolver.ts
+++ b/src/core/git-resolver.ts
@@ -267,10 +267,15 @@ export class GitResolver {
 
   /**
    * Parse version specification
+   *
+   * When no version spec is provided, returns `type: 'default'` so that
+   * `resolveVersion` auto-detects the repo's real default branch via HEAD.
+   * Previously this returned `branch:main`, which broke installs for repos
+   * whose default branch is not `main` (e.g. self-hosted GitLab with `master`).
    */
   parseVersion(versionSpec?: string): ParsedVersion {
     if (!versionSpec) {
-      return { type: 'branch', value: 'main', raw: '' };
+      return { type: 'default', value: '', raw: '' };
     }
 
     const raw = versionSpec;
@@ -365,6 +370,12 @@ export class GitResolver {
 
       case 'commit':
         return { ref: versionSpec.value, commit: versionSpec.value };
+
+      case 'default': {
+        // No version spec: clone the repository's real default branch.
+        const defaultBranch = await getDefaultBranch(repoUrl);
+        return { ref: defaultBranch };
+      }
 
       default:
         throw new Error(`Unknown version type: ${(versionSpec as ParsedVersion).type}`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -238,7 +238,8 @@ export type VersionType =
   | 'latest' // latest
   | 'range' // ^2.0.0, ~1.0.0
   | 'branch' // branch:develop
-  | 'commit'; // commit:abc1234
+  | 'commit' // commit:abc1234
+  | 'default'; // (no version spec) — auto-detect repo default branch via HEAD
 
 /**
  * Parsed version information


### PR DESCRIPTION
## Summary

Fix `reskill install <skill>` failing with `Failed to clone repository` for any repo whose default branch is not `main`. Most common real-world case: self-hosted GitLab EE repos with `master` as default.

**Changes**:
- Introduce new `'default'` \`VersionType\` representing "no version spec provided"
- `parseVersion(undefined | '')` now returns \`{ type: 'default', value: '', raw: '' }\` instead of \`{ type: 'branch', value: 'main' }\`
- `resolveVersion` handles `'default'` by calling \`getDefaultBranch(repoUrl)\` (same mechanism already used by `@latest` when no tags exist)
- Docs & changeset (patch)

## Why

The resolver had this dead-giveaway of a bug right next to the correct pattern:

```ts
parseVersion(versionSpec?: string): ParsedVersion {
  if (!versionSpec) {
    return { type: 'branch', value: 'main', raw: '' };  // ❌ hard-coded 'main'
  }
  // ...
}

// ...

case 'latest': {
  const latestTag = await getLatestTag(repoUrl);
  if (!latestTag) {
    const defaultBranch = await getDefaultBranch(repoUrl);  // ✅ auto-detect
    return { ref: defaultBranch };
  }
  // ...
}

case 'branch':
  return { ref: versionSpec.value };  // blindly trusts 'main'
```

So the correct behavior (`getDefaultBranch` via `git ls-remote --symref HEAD`) already existed — it just wasn't hooked up to the default path.

Docs in `docs/cli-spec.md` already said the (none) behavior is "Default branch", but the implementation interpreted "default branch" as the literal string `main`. This PR aligns behavior with docs.

**Real-world impact**: On internal self-hosted GitLab EE (`gitlab-ee.zhenguanyu.com`), most repos use `master` as default. Every skill published from such a repo would fail to install, with no workaround other than publishing with an explicit `/-/tree/<branch>` in the source URL.

## Behavior details

| Reference | Before | After |
|---|---|---|
| `@scope/foo` (no version) | clone `-b main` | clone default branch (HEAD) |
| `@scope/foo@main` / `@main` | clone `-b main` | clone `-b main` (unchanged) |
| `@scope/foo@branch:master` | clone `-b master` | clone `-b master` (unchanged) |
| `@scope/foo@latest` | clone latest tag or default branch | clone latest tag or default branch (unchanged) |
| `@scope/foo@v1.2.3` | clone `-b v1.2.3` | clone `-b v1.2.3` (unchanged) |

No behavior change for any explicit version spec. Only the "no spec" default is fixed.

## Test plan

- [x] Red tests added first, failed as expected, then green after fix
  - \`parseVersion(undefined)\` returns \`{ type: 'default' }\`
  - \`parseVersion('')\` returns \`{ type: 'default' }\`
  - \`resolveVersion({ type: 'default' })\` calls \`getDefaultBranch(repoUrl)\`
  - \`resolveVersion({ type: 'branch', value: 'main' })\` does NOT call \`getDefaultBranch\` (explicit main preserved)
  - \`resolve('user/skill')\` end-to-end returns the auto-detected ref
- [x] Existing \`parseVersion\` assertions updated (2 spots)
- [x] Full test suite: 1493/1493 passed (11 skipped)
- [x] TypeCheck (\`tsc --noEmit\`): 0 errors
- [x] Lint: no new errors
- [x] End-to-end on real self-hosted GitLab EE: \`install\` now succeeds with log \`✅ Installed <skill>@master to 4 agent(s)\`

Made with [Cursor](https://cursor.com)