### PR TITLE
feat: registry install 优先使用 OSS artifact

### DIFF
--- a/.changeset/oss-artifact-priority.md
+++ b/.changeset/oss-artifact-priority.md
@@ -1,0 +1,5 @@
+---
+"reskill": patch
+---
+
+registry install 优先使用 OSS artifact，gitlab/github skill 有版本记录时走 OSS 下载而非 git clone

--- a/.changeset/oss-artifact-priority.md
+++ b/.changeset/oss-artifact-priority.md
@@ -2,4 +2,8 @@
 "reskill": patch
 ---
 
+Prioritize OSS artifact download for registry install. Skills from gitlab/github with published version records now use OSS download instead of git clone.
+
+---
+
 registry install 优先使用 OSS artifact，gitlab/github skill 有版本记录时走 OSS 下载而非 git clone

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -1558,6 +1558,118 @@ describe('SkillManager installToAgentsFromRegistry with source_type', () => {
     });
   });
 
+  describe('hasArtifacts: OSS artifact takes priority over web-published fallback', () => {
+    it('should use registry flow for github source_type with OSS artifacts (latest_version)', async () => {
+      const { RegistryClient } = await import('./registry-client.js');
+      vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockResolvedValue({
+        name: '@kanyun/github-with-oss',
+        source_type: 'github',
+        source_url: 'https://github.com/user/repo',
+        latest_version: '1.0.0',
+        dist_tags: [{ tag: 'latest', version: '1.0.0' }],
+      });
+
+      // Mock RegistryResolver (standard registry flow)
+      const registryResolver = (manager as unknown as { registryResolver: RegistryResolver })
+        .registryResolver;
+      vi.spyOn(registryResolver, 'resolve').mockResolvedValue({
+        parsed: {
+          scope: '@kanyun',
+          name: 'github-with-oss',
+          version: '1.0.0',
+          fullName: '@kanyun/github-with-oss',
+        },
+        shortName: 'github-with-oss',
+        version: '1.0.0',
+        registryUrl: 'https://registry.example.com/',
+        tarball: Buffer.from('mock tarball'),
+        integrity: 'sha256-mockhash',
+      });
+
+      const mockSkillDir = path.join(tempDir, 'mock-github-oss');
+      fs.mkdirSync(mockSkillDir, { recursive: true });
+      fs.writeFileSync(path.join(mockSkillDir, 'SKILL.md'), '# Skill');
+      vi.spyOn(registryResolver, 'extract').mockResolvedValue(mockSkillDir);
+
+      // Should NOT call installFromWebPublished / installToAgentsFromGit
+      const installFromGitSpy = vi
+        .spyOn(
+          manager as unknown as Record<string, (...args: unknown[]) => unknown>,
+          'installToAgentsFromGit',
+        )
+        .mockResolvedValue({
+          skill: { name: 'github-with-oss', path: '/tmp/skill', version: '1.0.0', source: 'github' },
+          results: new Map([['cursor', { success: true, path: '/tmp', mode: 'symlink' }]]),
+        });
+
+      const result = await manager.installToAgents('@kanyun/github-with-oss', ['cursor']);
+
+      // Should go through registry flow, NOT git clone
+      expect(installFromGitSpy).not.toHaveBeenCalled();
+      expect(result.skill.name).toBe('github-with-oss');
+    });
+
+    it('should use registry flow for gitlab source_type with dist_tags only', async () => {
+      const { RegistryClient } = await import('./registry-client.js');
+      vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockResolvedValue({
+        name: '@kanyun/gitlab-with-oss',
+        source_type: 'gitlab',
+        source_url: 'https://gitlab.com/org/repo',
+        dist_tags: [{ tag: 'latest', version: '2.0.0' }],
+      });
+
+      const registryResolver = (manager as unknown as { registryResolver: RegistryResolver })
+        .registryResolver;
+      vi.spyOn(registryResolver, 'resolve').mockResolvedValue({
+        parsed: {
+          scope: '@kanyun',
+          name: 'gitlab-with-oss',
+          version: '2.0.0',
+          fullName: '@kanyun/gitlab-with-oss',
+        },
+        shortName: 'gitlab-with-oss',
+        version: '2.0.0',
+        registryUrl: 'https://registry.example.com/',
+        tarball: Buffer.from('mock tarball'),
+        integrity: 'sha256-mockhash',
+      });
+
+      const mockSkillDir = path.join(tempDir, 'mock-gitlab-oss');
+      fs.mkdirSync(mockSkillDir, { recursive: true });
+      fs.writeFileSync(path.join(mockSkillDir, 'SKILL.md'), '# Skill');
+      vi.spyOn(registryResolver, 'extract').mockResolvedValue(mockSkillDir);
+
+      const result = await manager.installToAgents('@kanyun/gitlab-with-oss', ['cursor']);
+
+      expect(result.skill.name).toBe('gitlab-with-oss');
+    });
+
+    it('should fall back to git clone for github source_type without artifacts', async () => {
+      const { RegistryClient } = await import('./registry-client.js');
+      vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockResolvedValue({
+        name: '@kanyun/github-no-oss',
+        source_type: 'github',
+        source_url: 'https://github.com/user/old-repo',
+        // no latest_version, no dist_tags
+      });
+
+      const installFromGitSpy = vi
+        .spyOn(
+          manager as unknown as Record<string, (...args: unknown[]) => unknown>,
+          'installToAgentsFromGit',
+        )
+        .mockResolvedValue({
+          skill: { name: 'github-no-oss', path: '/tmp/skill', version: '1.0.0', source: 'github' },
+          results: new Map([['cursor', { success: true, path: '/tmp', mode: 'symlink' }]]),
+        });
+
+      await manager.installToAgents('@kanyun/github-no-oss', ['cursor']);
+
+      // Should fall back to git clone
+      expect(installFromGitSpy).toHaveBeenCalled();
+    });
+  });
+
   describe('skill_path 支持（多技能仓库）', () => {
     it('should construct ref with skill_path for github source_type', async () => {
       const { RegistryClient } = await import('./registry-client.js');

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1374,9 +1374,14 @@ export class SkillManager {
       }
     }
 
-    // Branch based on source_type (pass resolved registryUrl via options to avoid re-computation)
+    // Branch: if skill has OSS artifacts (new publish flow), use standard registry download
+    // regardless of source_type. Old data without artifacts falls back to web-published path.
     const sourceType = skillInfo.source_type;
-    if (sourceType && sourceType !== 'registry') {
+    const hasArtifacts = skillInfo.latest_version
+      || (skillInfo.dist_tags && skillInfo.dist_tags.length > 0);
+
+    if (sourceType && sourceType !== 'registry' && !hasArtifacts) {
+      // Old data: no artifact, web-published skill → use git/http resolver
       return this.installFromWebPublished(skillInfo, parsed, targetAgents, {
         ...options,
         registry: registryUrl,

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1375,13 +1375,14 @@ export class SkillManager {
     }
 
     // Branch: if skill has OSS artifacts (new publish flow), use standard registry download
-    // regardless of source_type. Old data without artifacts falls back to web-published path.
+    // regardless of source_type. Legacy web-published skills without artifacts fall back
+    // to git clone / HTTP download via installFromWebPublished.
     const sourceType = skillInfo.source_type;
-    const hasArtifacts = skillInfo.latest_version
-      || (skillInfo.dist_tags && skillInfo.dist_tags.length > 0);
+    const hasArtifacts = !!skillInfo.latest_version
+      || (Array.isArray(skillInfo.dist_tags) && skillInfo.dist_tags.length > 0);
 
     if (sourceType && sourceType !== 'registry' && !hasArtifacts) {
-      // Old data: no artifact, web-published skill → use git/http resolver
+      // Legacy web-published skill without OSS artifacts → use git/http resolver
       return this.installFromWebPublished(skillInfo, parsed, targetAgents, {
         ...options,
         registry: registryUrl,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -403,4 +403,8 @@ export interface SkillInfo {
   created_at?: string;
   /** Last update timestamp */
   updated_at?: string;
+  /** Latest version from dist_tags (present when skill has published artifacts) */
+  latest_version?: string;
+  /** Dist tags array (e.g. [{ tag: 'latest', version: '1.0.0' }]) */
+  dist_tags?: Array<{ tag: string; version: string }>;
 }


### PR DESCRIPTION
## Summary

- 当 gitlab/github 类型的 skill 有 OSS artifact 时，走标准 registry download（OSS 签名 URL），不再 fallback 到 git clone
- `SkillInfo` 新增 `latest_version`、`dist_tags` 字段，用于判断是否有 artifact
- 配合 [rush-app#944](https://github.com/kanyun-inc/rush-app/pull/944)：Remote URL 发布现在会下载源码上传 OSS 并写入版本记录

## Test plan

- [ ] 安装一个已有 OSS artifact 的 gitlab skill → 走 OSS 下载（不触发 git clone）
- [ ] 安装一个无 artifact 的老 gitlab skill → fallback 到 git clone（向后兼容）

🤖 Generated with [Claude Code](https://claude.com/claude-code)