### PR TITLE
fix(registry): tolerate empty x-integrity header for local-mode publishes

### DIFF
--- a/.changeset/empty-integrity-tolerance.md
+++ b/.changeset/empty-integrity-tolerance.md
@@ -1,0 +1,15 @@
+---
+"reskill": patch
+---
+
+Tolerate empty `x-integrity` header from registry for local-mode publishes.
+
+**Bug Fixes:**
+- Fix `Invalid integrity format:` install failure when registry returns an empty `x-integrity` header. Per the rush-v2 server spec (§3.2a/3.2b), local-mode publishes (skills uploaded as multipart tarballs via the Web UI) intentionally store `integrity = ''` and the download endpoint propagates that empty value. The CLI now skips integrity verification in this case instead of throwing, while still verifying every non-empty integrity value as before.
+
+---
+
+兼容 registry 在 local 模式发布时返回的空 `x-integrity` header。
+
+**Bug Fixes:**
+- 修复 registry 返回空 `x-integrity` header 时安装报错 `Invalid integrity format:` 的问题。按 rush-v2 服务端契约（§3.2a/3.2b），local 模式发布的 skill（通过 Web UI 上传 multipart tarball）会有意将 `integrity` 存为空串，下载接口照样透传该空值。CLI 现在在这种情况下跳过完整性校验而不是抛错，对所有非空 integrity 仍按原有逻辑严格校验。

--- a/src/core/registry-resolver.test.ts
+++ b/src/core/registry-resolver.test.ts
@@ -4,7 +4,8 @@
  * Tests for detecting and resolving registry skill references
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RegistryClient } from './registry-client.js';
 import { RegistryResolver } from './registry-resolver.js';
 
 describe('RegistryResolver', () => {
@@ -151,6 +152,70 @@ describe('RegistryResolver', () => {
       // Verify the method signature accepts up to three parameters
       expect(resolver.resolve).toBeDefined();
       expect(resolver.resolve.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  // ====================================================================
+  // resolve() integrity handling
+  //
+  // The server contract (rush-v2 server-api.spec.md §3.2a/3.2b) explicitly
+  // allows the `x-integrity` header to be an empty string for local-mode
+  // publishes (skills uploaded as multipart tarball via Web UI). The CLI
+  // must tolerate this and skip integrity verification, otherwise install
+  // fails with "Invalid integrity format:" for any local-mode skill.
+  // ====================================================================
+
+  describe('resolve integrity handling', () => {
+    const TEST_REGISTRY = 'https://rush-test.zhenguanyu.com/';
+    const TARBALL_CONTENT = Buffer.from('mock-tarball-bytes');
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function mockClient(integrity: string): void {
+      vi.spyOn(RegistryClient.prototype, 'resolveVersion').mockResolvedValue('1.0.0');
+      vi.spyOn(RegistryClient.prototype, 'downloadSkill').mockResolvedValue({
+        tarball: TARBALL_CONTENT,
+        integrity,
+      });
+    }
+
+    it('should resolve successfully when server returns valid matching integrity', async () => {
+      const expected = RegistryClient.calculateIntegrity(TARBALL_CONTENT);
+      mockClient(expected);
+
+      const resolver = new RegistryResolver();
+      const result = await resolver.resolve('@kanyun/test-skill@1.0.0', TEST_REGISTRY);
+
+      expect(result.shortName).toBe('test-skill');
+      expect(result.version).toBe('1.0.0');
+      expect(result.integrity).toBe(expected);
+      expect(result.tarball).toBe(TARBALL_CONTENT);
+    });
+
+    it('should throw when server returns non-empty integrity that does not match tarball', async () => {
+      mockClient('sha256-tamperedhash000000000000000000000000000000');
+
+      const resolver = new RegistryResolver();
+
+      await expect(resolver.resolve('@kanyun/test-skill@1.0.0', TEST_REGISTRY)).rejects.toThrow(
+        /Integrity verification failed/,
+      );
+    });
+
+    it('should resolve successfully when server returns empty integrity (local-mode publish)', async () => {
+      // Local-mode publishes intentionally store integrity as '' on the server side.
+      // CLI must skip verification rather than throw "Invalid integrity format:".
+      mockClient('');
+
+      const resolver = new RegistryResolver();
+      const result = await resolver.resolve('@kanyun/local-skill@1.0.0', TEST_REGISTRY);
+
+      expect(result.shortName).toBe('local-skill');
+      expect(result.version).toBe('1.0.0');
+      expect(result.integrity).toBe('');
+      expect(result.tarball).toBe(TARBALL_CONTENT);
     });
   });
 });

--- a/src/core/registry-resolver.ts
+++ b/src/core/registry-resolver.ts
@@ -8,6 +8,7 @@
  * Uses RegistryClient to download and verify skills.
  */
 
+import { logger } from '../utils/logger.js';
 import {
   getRegistryUrl,
   getShortName,
@@ -108,7 +109,11 @@ export class RegistryResolver {
    * console.log(result.shortName); // 'planning-with-files'
    * console.log(result.version); // '2.4.5'
    */
-  async resolve(ref: string, overrideRegistryUrl?: string, token?: string): Promise<RegistryResolveResult> {
+  async resolve(
+    ref: string,
+    overrideRegistryUrl?: string,
+    token?: string,
+  ): Promise<RegistryResolveResult> {
     // 1. Parse skill identifier
     const parsed = parseSkillIdentifier(ref);
     const shortName = getShortName(parsed.fullName);
@@ -124,9 +129,20 @@ export class RegistryResolver {
     const { tarball, integrity } = await client.downloadSkill(parsed.fullName, version);
 
     // 5. Verify integrity
-    const isValid = RegistryClient.verifyIntegrity(tarball, integrity);
-    if (!isValid) {
-      throw new Error(`Integrity verification failed for ${ref}`);
+    //
+    // The server contract (rush-v2 server-api.spec.md §3.2a/3.2b) explicitly
+    // returns an empty `x-integrity` header for local-mode publishes — i.e.
+    // skills uploaded as a multipart tarball via the Web UI store integrity
+    // as ''. Skip verification in that case rather than failing install.
+    if (integrity) {
+      const isValid = RegistryClient.verifyIntegrity(tarball, integrity);
+      if (!isValid) {
+        throw new Error(`Integrity verification failed for ${ref}`);
+      }
+    } else {
+      logger.debug(
+        `Server returned empty integrity for ${ref}; skipping verification (expected for local-mode publishes).`,
+      );
     }
 
     return {


### PR DESCRIPTION
## Summary

Fix `Invalid integrity format:` install failure for skills published via the Web UI's **local mode** (multipart tarball upload).

## Root Cause

The rush-v2 server spec ([§3.2a/3.2b](https://github.com/kanyun-inc/rush-app/blob/main/specs/rush-v2/skill/server-api.spec.md)) explicitly defines that local-mode publishes store `integrity` as an empty string in `skill_versions`, and the `GET /api/skills/{name}/versions/{version}/download` endpoint propagates this empty value via the `x-integrity` response header.

On the CLI side, `RegistryResolver.resolve()` was unconditionally piping the header value into `RegistryClient.verifyIntegrity(tarball, '')`, which threw `Invalid integrity format:` because the regex `/^(\w+)-(.+)$/` does not match an empty string. Any user trying to install a local-mode skill (e.g. `@kanyun/intranet-auth`) hit this hard-fail.

## Fix

In `RegistryResolver.resolve()`:

- If the server returns a **non-empty** `x-integrity`, run strict SHA verification as before — and fail the install when it doesn't match.
- If the server returns an **empty** `x-integrity` (the documented contract for local-mode publishes), log a `debug` message and skip verification.

## Tests (TDD)

- **RED**: Added unit test in `src/core/registry-resolver.test.ts` that mocks `downloadSkill` to return `{ tarball, integrity: '' }` and expects `resolve()` to succeed. This test failed with `Invalid integrity format:` before the fix, confirming the reproduction.
- **GREEN**: Implemented the conditional, all 29 tests in the file pass.
- Also added two sibling tests covering valid-matching and tampered (non-empty mismatch) integrity to lock in the strict path.

## Manual Verification

Tested all 3 publish source types end-to-end with the freshly built CLI:

| source_type | skill | result |
|---|---|---|
| `local` (empty integrity, **fix target**) | `@kanyun/intranet-auth@1.2.0` | ✅ |
| `local` (empty integrity) | `@kanyun/google-typescript-style@1.0.0` | ✅ |
| `registry` (CLI publish, sha256 verified) | `@kanyun/git-commit-push@1.0.0` | ✅ |
| `registry` (CLI publish, sha256 verified) | `@kanyun/poseidon-grayscale@1.0.0` | ✅ |
| `gitlab` (Web Remote URL → OSS artifact, sha256 verified) | `@kanyun/skill-order_logistics-data_query@1.1.0` | ✅ |

No regressions in the strict-verification paths.

## Test Plan

- [x] `pnpm test:run` (1488 passed)
- [x] `pnpm typecheck`
- [x] `pnpm biome check` on changed files
- [x] Manual: `node dist/cli/index.js install @kanyun/intranet-auth -y` (previously failing) now installs successfully
- [x] Manual: install a sample of registry / gitlab / local source types — all OK


Made with [Cursor](https://cursor.com)