### PR TITLE
[codex] Add Claude Cowork 3P support

### DIFF
--- a/.changeset/claude-cowork-3p-safety.md
+++ b/.changeset/claude-cowork-3p-safety.md
@@ -1,0 +1,9 @@
+---
+"reskill": minor
+---
+
+Add experimental Claude Cowork 3P support, including app-managed skills root discovery, manifest updates, copy-based installation, uninstall/list support, safety checks for skill paths, and README documentation marked as Beta.
+
+---
+
+新增实验性的 Claude Cowork 3P 支持，包括 App 管理的 skills root 发现、manifest 更新、基于 copy 的安装、卸载和列表支持、技能路径安全校验，以及 README 中标记为 Beta 的说明文档。

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Skills are installed to `.skills/` by default and can be integrated with any age
 | Amp            | `.agents/skills`   |
 | Antigravity    | `.agent/skills`    |
 | Claude Code    | `.claude/skills`   |
+| Claude Cowork 3P (Beta) | App-managed `Claude-3p/local-agent-mode-sessions/skills-plugin/<org>/<account>/skills` |
 | Clawdbot       | `skills`           |
 | Codex          | `.codex/skills`    |
 | Cursor         | `.cursor/skills`   |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -232,6 +232,7 @@ Skills 默认安装到 `.skills/`，可与任何 Agent 集成：
 | Amp            | `.agents/skills`   |
 | Antigravity    | `.agent/skills`    |
 | Claude Code    | `.claude/skills`   |
+| Claude Cowork 3P（Beta） | App 管理的 `Claude-3p/local-agent-mode-sessions/skills-plugin/<org>/<account>/skills` |
 | Clawdbot       | `skills`           |
 | Codex          | `.codex/skills`    |
 | Cursor         | `.cursor/skills`   |

--- a/src/core/agent-registry.test.ts
+++ b/src/core/agent-registry.test.ts
@@ -1,6 +1,7 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   type AgentType,
   agents,
@@ -10,12 +11,23 @@ import {
   getAllAgentTypes,
   isValidAgentType,
 } from './agent-registry.js';
+import { CLAUDE_3P_SKILLS_ROOT_ENV } from './claude-3p-installer.js';
 
 describe('agent-registry', () => {
+  const originalClaude3pRoot = process.env[CLAUDE_3P_SKILLS_ROOT_ENV];
+
+  afterEach(() => {
+    if (originalClaude3pRoot === undefined) {
+      delete process.env[CLAUDE_3P_SKILLS_ROOT_ENV];
+    } else {
+      process.env[CLAUDE_3P_SKILLS_ROOT_ENV] = originalClaude3pRoot;
+    }
+  });
+
   describe('agents config', () => {
-    it('should have 17 agents defined', () => {
+    it('should have 18 agents defined', () => {
       const agentKeys = Object.keys(agents);
-      expect(agentKeys.length).toBe(17);
+      expect(agentKeys.length).toBe(18);
     });
 
     it('should have all expected agents', () => {
@@ -23,6 +35,7 @@ describe('agent-registry', () => {
         'amp',
         'antigravity',
         'claude-code',
+        'claude-cowork-3p',
         'clawdbot',
         'codex',
         'cursor',
@@ -81,6 +94,15 @@ describe('agent-registry', () => {
       expect(agents['claude-code'].globalSkillsDir).toBe(path.join(home, '.claude/skills'));
     });
 
+    it('claude-cowork-3p agent should have correct configuration', () => {
+      expect(agents['claude-cowork-3p'].name).toBe('claude-cowork-3p');
+      expect(agents['claude-cowork-3p'].displayName).toBe('Claude Cowork 3P');
+      expect(agents['claude-cowork-3p'].skillsDir).toBe('.claude-3p/skills');
+      expect(agents['claude-cowork-3p'].globalSkillsDir).toContain(
+        path.join('Claude-3p', 'local-agent-mode-sessions', 'skills-plugin'),
+      );
+    });
+
     it('github-copilot agent should have correct configuration', () => {
       const home = os.homedir();
       expect(agents['github-copilot'].name).toBe('github-copilot');
@@ -104,6 +126,7 @@ describe('agent-registry', () => {
     it('should return true for valid agent types', () => {
       expect(isValidAgentType('cursor')).toBe(true);
       expect(isValidAgentType('claude-code')).toBe(true);
+      expect(isValidAgentType('claude-cowork-3p')).toBe(true);
       expect(isValidAgentType('github-copilot')).toBe(true);
       expect(isValidAgentType('windsurf')).toBe(true);
       expect(isValidAgentType('amp')).toBe(true);
@@ -141,9 +164,10 @@ describe('agent-registry', () => {
     it('should return array of all agent types', () => {
       const types = getAllAgentTypes();
       expect(Array.isArray(types)).toBe(true);
-      expect(types.length).toBe(17);
+      expect(types.length).toBe(18);
       expect(types).toContain('cursor');
       expect(types).toContain('claude-code');
+      expect(types).toContain('claude-cowork-3p');
       expect(types).toContain('github-copilot');
     });
   });
@@ -175,6 +199,20 @@ describe('agent-registry', () => {
       expect(getAgentSkillsDir('windsurf', { global: true })).toBe(
         path.join(home, '.codeium/windsurf/skills'),
       );
+    });
+
+    it('should return Claude Cowork 3P app-managed skills directory', () => {
+      const tempDir = mkdtempSync(path.join(os.tmpdir(), 'claude-3p-agent-registry-test-'));
+      const skillsRoot = path.join(tempDir, 'skills-plugin', 'org', 'account');
+      mkdirSync(path.join(skillsRoot, 'skills'), { recursive: true });
+      writeFileSync(path.join(skillsRoot, 'manifest.json'), '{"skills":[]}\n');
+      process.env[CLAUDE_3P_SKILLS_ROOT_ENV] = skillsRoot;
+
+      try {
+        expect(getAgentSkillsDir('claude-cowork-3p')).toBe(path.join(skillsRoot, 'skills'));
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/src/core/agent-registry.ts
+++ b/src/core/agent-registry.ts
@@ -1,13 +1,18 @@
 /**
  * Agent Registry - Multi-Agent configuration definitions
  *
- * Supports global and project-level installation for 17 coding agents
+ * Supports global and project-level installation for 18 coding agents
  * Reference: https://github.com/vercel-labs/add-skill
  */
 
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import {
+  CLAUDE_COWORK_3P_AGENT,
+  getClaude3pSkillsPluginBase,
+  resolveClaude3pSkillsRoot,
+} from './claude-3p-installer.js';
 
 /**
  * Supported Agent types
@@ -16,6 +21,7 @@ export type AgentType =
   | 'amp'
   | 'antigravity'
   | 'claude-code'
+  | 'claude-cowork-3p'
   | 'clawdbot'
   | 'codex'
   | 'cursor'
@@ -80,6 +86,20 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.claude/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.claude'));
+    },
+  },
+  [CLAUDE_COWORK_3P_AGENT]: {
+    name: CLAUDE_COWORK_3P_AGENT,
+    displayName: 'Claude Cowork 3P',
+    skillsDir: '.claude-3p/skills',
+    globalSkillsDir: getClaude3pSkillsPluginBase(),
+    detectInstalled: async () => {
+      try {
+        resolveClaude3pSkillsRoot();
+        return true;
+      } catch {
+        return false;
+      }
     },
   },
   clawdbot: {
@@ -248,12 +268,19 @@ export function isValidAgentType(type: string): type is AgentType {
 
 /**
  * Get Agent's project-level skills directory
+ *
+ * Claude Cowork 3P stores skills under an app-managed account directory. This
+ * throws when that directory cannot be resolved, for example when the app has
+ * not initialized skills or multiple local account roots exist.
  */
 export function getAgentSkillsDir(
   type: AgentType,
   options: { global?: boolean; cwd?: string } = {},
 ): string {
   const config = agents[type];
+  if (type === CLAUDE_COWORK_3P_AGENT) {
+    return join(resolveClaude3pSkillsRoot(), 'skills');
+  }
   if (options.global) {
     return config.globalSkillsDir;
   }

--- a/src/core/claude-3p-installer.test.ts
+++ b/src/core/claude-3p-installer.test.ts
@@ -196,4 +196,13 @@ description: Unsafe skill
       ),
     ).toEqual([]);
   });
+
+  it('reports copy mode when installation fails after requesting symlink mode', () => {
+    writeFileSync(path.join(skillsRoot, 'manifest.json'), '{broken');
+
+    const result = installClaude3pSkill(sourceDir, 'fallback-skill', { mode: 'symlink' });
+
+    expect(result.success).toBe(false);
+    expect(result.mode).toBe('copy');
+  });
 });

--- a/src/core/claude-3p-installer.test.ts
+++ b/src/core/claude-3p-installer.test.ts
@@ -1,0 +1,199 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CLAUDE_3P_SKILLS_PLUGIN_BASE_ENV,
+  CLAUDE_3P_SKILLS_ROOT_ENV,
+  findClaude3pSkillsRoots,
+  getClaude3pSkillPath,
+  getClaude3pSkillsPluginBase,
+  installClaude3pSkill,
+  listClaude3pSkills,
+  resolveClaude3pSkillsRoot,
+  uninstallClaude3pSkill,
+} from './claude-3p-installer.js';
+
+describe('claude-3p-installer', () => {
+  let tempDir: string;
+  let sourceDir: string;
+  let skillsRoot: string;
+  let originalRoot: string | undefined;
+  let originalBase: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'claude-3p-installer-test-'));
+    skillsRoot = path.join(tempDir, 'skills-plugin', 'org', 'account');
+    mkdirSync(path.join(skillsRoot, 'skills'), { recursive: true });
+    writeFileSync(path.join(skillsRoot, 'manifest.json'), '{"skills":[]}\n');
+
+    sourceDir = path.join(tempDir, 'source');
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(
+      path.join(sourceDir, 'SKILL.md'),
+      `---
+name: test-skill
+description: Test skill for Claude Cowork 3P
+---
+
+# Test Skill
+`,
+    );
+    writeFileSync(path.join(sourceDir, 'helper.md'), '# Helper');
+    writeFileSync(path.join(sourceDir, 'README.md'), '# Excluded');
+
+    originalRoot = process.env[CLAUDE_3P_SKILLS_ROOT_ENV];
+    originalBase = process.env[CLAUDE_3P_SKILLS_PLUGIN_BASE_ENV];
+    process.env[CLAUDE_3P_SKILLS_ROOT_ENV] = skillsRoot;
+    delete process.env[CLAUDE_3P_SKILLS_PLUGIN_BASE_ENV];
+  });
+
+  afterEach(() => {
+    if (originalRoot === undefined) {
+      delete process.env[CLAUDE_3P_SKILLS_ROOT_ENV];
+    } else {
+      process.env[CLAUDE_3P_SKILLS_ROOT_ENV] = originalRoot;
+    }
+
+    if (originalBase === undefined) {
+      delete process.env[CLAUDE_3P_SKILLS_PLUGIN_BASE_ENV];
+    } else {
+      process.env[CLAUDE_3P_SKILLS_PLUGIN_BASE_ENV] = originalBase;
+    }
+
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('derives the platform-specific skills-plugin base path', () => {
+    expect(
+      getClaude3pSkillsPluginBase({
+        platform: 'darwin',
+        homeDir: '/Users/alice',
+        env: {},
+      }),
+    ).toBe(
+      path.join(
+        '/Users/alice',
+        'Library',
+        'Application Support',
+        'Claude-3p',
+        'local-agent-mode-sessions',
+        'skills-plugin',
+      ),
+    );
+
+    expect(
+      getClaude3pSkillsPluginBase({
+        platform: 'win32',
+        homeDir: 'C:\\Users\\Alice',
+        env: { APPDATA: 'C:\\Users\\Alice\\AppData\\Roaming' },
+      }),
+    ).toBe(
+      path.join(
+        'C:\\Users\\Alice\\AppData\\Roaming',
+        'Claude-3p',
+        'local-agent-mode-sessions',
+        'skills-plugin',
+      ),
+    );
+  });
+
+  it('resolves an explicit Claude Cowork 3P skills root', () => {
+    expect(resolveClaude3pSkillsRoot()).toBe(skillsRoot);
+    expect(findClaude3pSkillsRoots()).toEqual([skillsRoot]);
+  });
+
+  it('installs a skill and updates Claude Cowork 3P manifest.json', () => {
+    const result = installClaude3pSkill(sourceDir, 'fallback-skill', { mode: 'symlink' });
+
+    expect(result.success).toBe(true);
+    expect(result.mode).toBe('copy');
+    expect(result.symlinkFailed).toBeUndefined();
+    expect(result.path).toBe(path.join(skillsRoot, 'skills', 'test-skill'));
+    expect(existsSync(path.join(result.path, 'SKILL.md'))).toBe(true);
+    expect(existsSync(path.join(result.path, 'helper.md'))).toBe(true);
+    expect(existsSync(path.join(result.path, 'README.md'))).toBe(false);
+
+    const manifest = JSON.parse(readFileSync(path.join(skillsRoot, 'manifest.json'), 'utf-8'));
+    expect(manifest.skills).toHaveLength(1);
+    expect(manifest.skills[0]).toMatchObject({
+      skillId: 'test-skill',
+      name: 'test-skill',
+      description: 'Test skill for Claude Cowork 3P',
+      creatorType: 'user',
+      syncManaged: false,
+      enabled: true,
+    });
+    expect(typeof manifest.lastUpdated).toBe('number');
+  });
+
+  it('uninstalls a skill and removes it from manifest.json', () => {
+    installClaude3pSkill(sourceDir, 'fallback-skill', { mode: 'copy' });
+
+    expect(listClaude3pSkills()).toEqual(['test-skill']);
+    expect(uninstallClaude3pSkill('test-skill')).toBe(true);
+    expect(listClaude3pSkills()).toEqual([]);
+
+    const manifest = JSON.parse(readFileSync(path.join(skillsRoot, 'manifest.json'), 'utf-8'));
+    expect(manifest.skills).toEqual([]);
+  });
+
+  it('rejects unsafe skill names that could escape the skills directory', () => {
+    writeFileSync(
+      path.join(sourceDir, 'SKILL.md'),
+      `---
+name: ..
+description: Unsafe skill
+---
+
+# Unsafe Skill
+`,
+    );
+
+    const result = installClaude3pSkill(sourceDir, 'fallback-skill', { mode: 'copy' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not safe');
+    expect(existsSync(path.join(skillsRoot, 'skills'))).toBe(true);
+    expect(
+      JSON.parse(readFileSync(path.join(skillsRoot, 'manifest.json'), 'utf-8')).skills,
+    ).toEqual([]);
+    expect(() => getClaude3pSkillPath('..')).toThrow('not safe');
+    expect(() => uninstallClaude3pSkill('.')).toThrow('not safe');
+  });
+
+  it('keeps only recent Claude Cowork 3P manifest backups', () => {
+    for (let index = 0; index < 12; index++) {
+      installClaude3pSkill(sourceDir, 'fallback-skill', { mode: 'copy' });
+    }
+
+    const backups = readdirSync(skillsRoot).filter((name) => name.startsWith('manifest.json.bak.'));
+    expect(backups.length).toBeLessThanOrEqual(10);
+  });
+
+  it('rolls back files when manifest update fails', () => {
+    installClaude3pSkill(sourceDir, 'fallback-skill', { mode: 'copy' });
+    writeFileSync(path.join(sourceDir, 'helper.md'), '# Updated helper');
+    writeFileSync(path.join(skillsRoot, 'manifest.json'), '{broken');
+
+    const result = installClaude3pSkill(sourceDir, 'fallback-skill', { mode: 'copy' });
+
+    expect(result.success).toBe(false);
+    expect(readFileSync(path.join(skillsRoot, 'skills', 'test-skill', 'helper.md'), 'utf-8')).toBe(
+      '# Helper',
+    );
+    expect(
+      readdirSync(path.join(skillsRoot, 'skills')).filter((name) =>
+        name.includes('test-skill.rollback'),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/src/core/claude-3p-installer.ts
+++ b/src/core/claude-3p-installer.ts
@@ -303,9 +303,8 @@ function removeFromManifest(manifestPath: string, skillId: string): void {
 export function installClaude3pSkill(
   sourcePath: string,
   fallbackName: string,
-  options: InstallOptions = {},
+  _options: InstallOptions = {},
 ): InstallResult {
-  const requestedMode = options.mode ?? 'symlink';
   const installMode = 'copy';
   let manifestPath: string | undefined;
   let manifestBackupPath: string | undefined;
@@ -393,7 +392,7 @@ export function installClaude3pSkill(
     return {
       success: false,
       path: '',
-      mode: requestedMode,
+      mode: installMode,
       error: error instanceof Error ? error.message : 'Unknown error',
     };
   }

--- a/src/core/claude-3p-installer.ts
+++ b/src/core/claude-3p-installer.ts
@@ -1,0 +1,427 @@
+import * as fs from 'node:fs';
+import { homedir, platform as nodePlatform } from 'node:os';
+import * as path from 'node:path';
+import { parseSkillFromDir } from './skill-parser.js';
+
+export const CLAUDE_COWORK_3P_AGENT = 'claude-cowork-3p';
+export const CLAUDE_3P_SKILLS_ROOT_ENV = 'CLAUDE_3P_SKILLS_ROOT';
+export const CLAUDE_3P_SKILLS_PLUGIN_BASE_ENV = 'CLAUDE_3P_SKILLS_PLUGIN_BASE';
+const DEFAULT_EXCLUDE_FILES = ['README.md', 'metadata.json', '.reskill-commit'];
+const EXCLUDE_PREFIX = '_';
+const MAX_MANIFEST_BACKUPS = 10;
+
+interface Claude3pManifestSkill {
+  skillId: string;
+  name: string;
+  description: string;
+  creatorType: string;
+  syncManaged: boolean;
+  updatedAt: string;
+  enabled: boolean;
+  [key: string]: unknown;
+}
+
+interface Claude3pManifest {
+  skills?: Claude3pManifestSkill[];
+  lastUpdated?: number;
+  [key: string]: unknown;
+}
+
+interface ResolvePathOptions {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  platform?: NodeJS.Platform;
+}
+
+interface InstallOptions {
+  mode?: 'symlink' | 'copy';
+}
+
+interface InstallResult {
+  success: boolean;
+  path: string;
+  canonicalPath?: string;
+  mode: 'symlink' | 'copy';
+  symlinkFailed?: boolean;
+  error?: string;
+}
+
+function exists(targetPath: string): boolean {
+  return fs.existsSync(targetPath);
+}
+
+function ensureDir(dirPath: string): void {
+  if (!exists(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+function remove(targetPath: string): void {
+  if (exists(targetPath)) {
+    fs.rmSync(targetPath, { recursive: true, force: true });
+  }
+}
+
+function isSafeSkillId(name: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name) && name !== '.' && name !== '..';
+}
+
+function isPathSafe(basePath: string, targetPath: string): boolean {
+  const normalizedBase = path.normalize(path.resolve(basePath));
+  const normalizedTarget = path.normalize(path.resolve(targetPath));
+
+  return normalizedTarget.startsWith(normalizedBase + path.sep);
+}
+
+function getSafeSkillPath(root: string, skillName: string): string {
+  if (!isSafeSkillId(skillName)) {
+    throw new Error(`Skill name is not safe for Claude Cowork 3P: ${skillName}`);
+  }
+
+  const skillsDir = path.join(root, 'skills');
+  const skillPath = path.join(skillsDir, skillName);
+  if (!isPathSafe(skillsDir, skillPath)) {
+    throw new Error(`Skill path escapes Claude Cowork 3P skills directory: ${skillName}`);
+  }
+
+  return skillPath;
+}
+
+function isSkillsRoot(root: string): boolean {
+  return exists(path.join(root, 'manifest.json')) && exists(path.join(root, 'skills'));
+}
+
+function copyDirectory(src: string, dest: string): void {
+  ensureDir(dest);
+
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    if (DEFAULT_EXCLUDE_FILES.includes(entry.name) || entry.name.startsWith(EXCLUDE_PREFIX)) {
+      continue;
+    }
+
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      copyDirectory(srcPath, destPath);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+export function getClaude3pSkillsPluginBase(options: ResolvePathOptions = {}): string {
+  const env = options.env ?? process.env;
+  const explicitBase = env[CLAUDE_3P_SKILLS_PLUGIN_BASE_ENV];
+  if (explicitBase) {
+    return explicitBase;
+  }
+
+  const homeDir = options.homeDir ?? homedir();
+  const currentPlatform = options.platform ?? nodePlatform();
+
+  if (currentPlatform === 'darwin') {
+    return path.join(
+      homeDir,
+      'Library',
+      'Application Support',
+      'Claude-3p',
+      'local-agent-mode-sessions',
+      'skills-plugin',
+    );
+  }
+
+  if (currentPlatform === 'win32') {
+    return path.join(
+      env.APPDATA ?? path.join(homeDir, 'AppData', 'Roaming'),
+      'Claude-3p',
+      'local-agent-mode-sessions',
+      'skills-plugin',
+    );
+  }
+
+  return path.join(
+    env.XDG_CONFIG_HOME ?? path.join(homeDir, '.config'),
+    'Claude-3p',
+    'local-agent-mode-sessions',
+    'skills-plugin',
+  );
+}
+
+export function findClaude3pSkillsRoots(options: ResolvePathOptions = {}): string[] {
+  const env = options.env ?? process.env;
+  const explicitRoot = env[CLAUDE_3P_SKILLS_ROOT_ENV];
+
+  if (explicitRoot) {
+    return isSkillsRoot(explicitRoot) ? [explicitRoot] : [];
+  }
+
+  const base = getClaude3pSkillsPluginBase(options);
+  if (!exists(base)) {
+    return [];
+  }
+
+  const roots: string[] = [];
+  for (const organization of fs.readdirSync(base, { withFileTypes: true })) {
+    if (!organization.isDirectory()) continue;
+
+    const organizationPath = path.join(base, organization.name);
+    for (const account of fs.readdirSync(organizationPath, { withFileTypes: true })) {
+      if (!account.isDirectory()) continue;
+
+      const candidate = path.join(organizationPath, account.name);
+      if (isSkillsRoot(candidate)) {
+        roots.push(candidate);
+      }
+    }
+  }
+
+  return roots;
+}
+
+export function resolveClaude3pSkillsRoot(options: ResolvePathOptions = {}): string {
+  const env = options.env ?? process.env;
+  const explicitRoot = env[CLAUDE_3P_SKILLS_ROOT_ENV];
+
+  if (explicitRoot) {
+    if (!isSkillsRoot(explicitRoot)) {
+      throw new Error(
+        `${CLAUDE_3P_SKILLS_ROOT_ENV} must contain manifest.json and skills/: ${explicitRoot}`,
+      );
+    }
+    return explicitRoot;
+  }
+
+  const roots = findClaude3pSkillsRoots(options);
+  if (roots.length === 1) {
+    return roots[0];
+  }
+
+  const base = getClaude3pSkillsPluginBase(options);
+  if (roots.length === 0) {
+    throw new Error(
+      `Claude Cowork 3P skills root not found under ${base}. Set ${CLAUDE_3P_SKILLS_ROOT_ENV} to the account directory containing manifest.json and skills/.`,
+    );
+  }
+
+  throw new Error(
+    `Multiple Claude Cowork 3P skills roots found. Set ${CLAUDE_3P_SKILLS_ROOT_ENV} to one of:\n${roots
+      .map((root) => `  ${root}`)
+      .join('\n')}`,
+  );
+}
+
+export function getClaude3pSkillPath(skillName: string): string {
+  const root = resolveClaude3pSkillsRoot();
+  return getSafeSkillPath(root, skillName);
+}
+
+function readManifest(manifestPath: string): Claude3pManifest {
+  const content = fs.readFileSync(manifestPath, 'utf-8');
+  return JSON.parse(content) as Claude3pManifest;
+}
+
+function writeManifest(manifestPath: string, manifest: Claude3pManifest): void {
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+}
+
+function createManifestBackup(manifestPath: string): string {
+  const backupPath = `${manifestPath}.bak.${Date.now()}`;
+  fs.copyFileSync(manifestPath, backupPath);
+  return backupPath;
+}
+
+function pruneManifestBackups(manifestPath: string): void {
+  const manifestDir = path.dirname(manifestPath);
+  const backupPrefix = `${path.basename(manifestPath)}.bak.`;
+  const backups = fs
+    .readdirSync(manifestDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.startsWith(backupPrefix))
+    .map((entry) => ({
+      name: entry.name,
+      path: path.join(manifestDir, entry.name),
+      mtimeMs: fs.statSync(path.join(manifestDir, entry.name)).mtimeMs,
+    }))
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const backup of backups.slice(MAX_MANIFEST_BACKUPS)) {
+    remove(backup.path);
+  }
+}
+
+function updateManifest(
+  manifestPath: string,
+  skillId: string,
+  name: string,
+  description: string,
+): void {
+  const manifest = readManifest(manifestPath);
+  if (!Array.isArray(manifest.skills)) {
+    manifest.skills = [];
+  }
+
+  const entry: Claude3pManifestSkill = {
+    skillId,
+    name,
+    description,
+    creatorType: 'user',
+    syncManaged: false,
+    updatedAt: new Date().toISOString(),
+    enabled: true,
+  };
+
+  const index = manifest.skills.findIndex(
+    (skill) => skill.skillId === skillId || skill.name === name,
+  );
+  if (index >= 0) {
+    manifest.skills[index] = { ...manifest.skills[index], ...entry };
+  } else {
+    manifest.skills.push(entry);
+  }
+
+  manifest.lastUpdated = Date.now();
+  writeManifest(manifestPath, manifest);
+}
+
+function removeFromManifest(manifestPath: string, skillId: string): void {
+  const manifest = readManifest(manifestPath);
+  if (!Array.isArray(manifest.skills)) {
+    return;
+  }
+
+  const before = manifest.skills.length;
+  manifest.skills = manifest.skills.filter(
+    (skill) => skill.skillId !== skillId && skill.name !== skillId,
+  );
+
+  if (manifest.skills.length !== before) {
+    manifest.lastUpdated = Date.now();
+    writeManifest(manifestPath, manifest);
+  }
+}
+
+export function installClaude3pSkill(
+  sourcePath: string,
+  fallbackName: string,
+  options: InstallOptions = {},
+): InstallResult {
+  const requestedMode = options.mode ?? 'symlink';
+  const installMode = 'copy';
+  let manifestPath: string | undefined;
+  let manifestBackupPath: string | undefined;
+  let targetPath: string | undefined;
+  let tmpTarget: string | undefined;
+  let rollbackTarget: string | undefined;
+
+  try {
+    const metadata = parseSkillFromDir(sourcePath);
+    const skillId = metadata?.name ?? fallbackName;
+    const description = metadata?.description ?? '';
+
+    if (!isSafeSkillId(skillId)) {
+      return {
+        success: false,
+        path: '',
+        mode: installMode,
+        error: `SKILL.md name is not safe for Claude Cowork 3P: ${skillId}`,
+      };
+    }
+
+    const root = resolveClaude3pSkillsRoot();
+    manifestPath = path.join(root, 'manifest.json');
+    const skillsDir = path.join(root, 'skills');
+    targetPath = getSafeSkillPath(root, skillId);
+    tmpTarget = path.join(skillsDir, `.${skillId}.installing.${process.pid}`);
+    rollbackTarget = path.join(skillsDir, `.${skillId}.rollback.${process.pid}`);
+    if (!isPathSafe(skillsDir, tmpTarget)) {
+      throw new Error(`Temporary skill path escapes Claude Cowork 3P skills directory: ${skillId}`);
+    }
+    if (!isPathSafe(skillsDir, rollbackTarget)) {
+      throw new Error(`Rollback skill path escapes Claude Cowork 3P skills directory: ${skillId}`);
+    }
+
+    manifestBackupPath = createManifestBackup(manifestPath);
+    remove(tmpTarget);
+    remove(rollbackTarget);
+    copyDirectory(sourcePath, tmpTarget);
+    if (exists(targetPath)) {
+      fs.renameSync(targetPath, rollbackTarget);
+    }
+    fs.renameSync(tmpTarget, targetPath);
+
+    try {
+      updateManifest(manifestPath, skillId, skillId, description);
+    } catch (error) {
+      remove(targetPath);
+      if (rollbackTarget && exists(rollbackTarget)) {
+        fs.renameSync(rollbackTarget, targetPath);
+      }
+      if (manifestBackupPath && manifestPath && exists(manifestBackupPath)) {
+        fs.copyFileSync(manifestBackupPath, manifestPath);
+      }
+      throw error;
+    }
+
+    if (rollbackTarget) {
+      remove(rollbackTarget);
+    }
+    pruneManifestBackups(manifestPath);
+
+    return {
+      success: true,
+      path: targetPath,
+      mode: installMode,
+    };
+  } catch (error) {
+    if (tmpTarget) {
+      remove(tmpTarget);
+    }
+    if (targetPath && rollbackTarget && exists(rollbackTarget) && !exists(targetPath)) {
+      try {
+        fs.renameSync(rollbackTarget, targetPath);
+      } catch {
+        // Ignore rollback errors while reporting the original installation failure.
+      }
+    }
+    if (manifestPath) {
+      try {
+        pruneManifestBackups(manifestPath);
+      } catch {
+        // Ignore cleanup errors while reporting the original installation failure.
+      }
+    }
+    return {
+      success: false,
+      path: '',
+      mode: requestedMode,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+export function uninstallClaude3pSkill(skillName: string): boolean {
+  const root = resolveClaude3pSkillsRoot();
+  const targetPath = getSafeSkillPath(root, skillName);
+  const manifestPath = path.join(root, 'manifest.json');
+  const existed = exists(targetPath);
+
+  if (existed) {
+    remove(targetPath);
+  }
+  removeFromManifest(manifestPath, skillName);
+
+  return existed;
+}
+
+export function listClaude3pSkills(): string[] {
+  const root = resolveClaude3pSkillsRoot();
+  const skillsDir = path.join(root, 'skills');
+  if (!exists(skillsDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(skillsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && isSafeSkillId(entry.name))
+    .map((entry) => entry.name);
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,14 +1,4 @@
 export type { AgentConfig, AgentType } from './agent-registry.js';
-// Content scanning
-export type {
-  RiskLevel,
-  ScanFinding,
-  ScannerOptions,
-  ScanResult,
-  ScanRule,
-  ScanRuleMatch,
-} from './content-scanner.js';
-export { ContentScanError, ContentScanner, DEFAULT_RULES, maskSafeZones } from './content-scanner.js';
 // Multi-Agent support
 export {
   agents,
@@ -22,7 +12,31 @@ export type { RegistryAuth, ReskillConfig } from './auth-manager.js';
 // Auth management
 export { AuthManager } from './auth-manager.js';
 export { CacheManager } from './cache-manager.js';
+export {
+  CLAUDE_3P_SKILLS_PLUGIN_BASE_ENV,
+  CLAUDE_3P_SKILLS_ROOT_ENV,
+  CLAUDE_COWORK_3P_AGENT,
+  findClaude3pSkillsRoots,
+  getClaude3pSkillPath,
+  getClaude3pSkillsPluginBase,
+  resolveClaude3pSkillsRoot,
+} from './claude-3p-installer.js';
 export { ConfigLoader, DEFAULT_REGISTRIES } from './config-loader.js';
+// Content scanning
+export type {
+  RiskLevel,
+  ScanFinding,
+  ScannerOptions,
+  ScanResult,
+  ScanRule,
+  ScanRuleMatch,
+} from './content-scanner.js';
+export {
+  ContentScanError,
+  ContentScanner,
+  DEFAULT_RULES,
+  maskSafeZones,
+} from './content-scanner.js';
 /**
  * Type representing well-known registry names
  */

--- a/src/core/installer.test.ts
+++ b/src/core/installer.test.ts
@@ -302,6 +302,17 @@ This is test content.
       expect(result).toBe(false);
     });
 
+    it('should reject unsafe Claude Cowork 3P names instead of sanitizing them', () => {
+      const skillsRoot = path.join(tempDir, 'claude-3p', 'org', 'account');
+      mkdirSync(path.join(skillsRoot, 'skills', 'unnamed-skill'), { recursive: true });
+      writeFileSync(path.join(skillsRoot, 'manifest.json'), '{"skills":[]}\n');
+      process.env[CLAUDE_3P_SKILLS_ROOT_ENV] = skillsRoot;
+
+      expect(installer.isInstalled('..', 'claude-cowork-3p')).toBe(false);
+      expect(installer.uninstallFromAgent('..', 'claude-cowork-3p')).toBe(false);
+      expect(existsSync(path.join(skillsRoot, 'skills', 'unnamed-skill'))).toBe(true);
+    });
+
     it('should only uninstall from specified agent', async () => {
       // Install to multiple agents
       await installer.installToAgents(sourceDir, 'test-skill', ['cursor', 'claude-code'], {

--- a/src/core/installer.test.ts
+++ b/src/core/installer.test.ts
@@ -4,12 +4,14 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getShortName } from '../utils/registry-scope.js';
 import type { AgentType } from './agent-registry.js';
+import { CLAUDE_3P_SKILLS_ROOT_ENV } from './claude-3p-installer.js';
 import { Installer } from './installer.js';
 
 describe('Installer', () => {
   let tempDir: string;
   let installer: Installer;
   let sourceDir: string;
+  let originalClaude3pRoot: string | undefined;
 
   beforeEach(() => {
     tempDir = mkdtempSync(path.join(tmpdir(), 'installer-test-'));
@@ -33,9 +35,15 @@ This is test content.
 
     // Create additional files
     writeFileSync(path.join(sourceDir, 'helper.md'), '# Helper file');
+    originalClaude3pRoot = process.env[CLAUDE_3P_SKILLS_ROOT_ENV];
   });
 
   afterEach(() => {
+    if (originalClaude3pRoot === undefined) {
+      delete process.env[CLAUDE_3P_SKILLS_ROOT_ENV];
+    } else {
+      process.env[CLAUDE_3P_SKILLS_ROOT_ENV] = originalClaude3pRoot;
+    }
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -122,6 +130,30 @@ This is test content.
         expect(result.success).toBe(true);
         expect(existsSync(result.path)).toBe(true);
       }
+    });
+
+    it('should install to Claude Cowork 3P and update its manifest', async () => {
+      const skillsRoot = path.join(tempDir, 'claude-3p', 'org', 'account');
+      mkdirSync(path.join(skillsRoot, 'skills'), { recursive: true });
+      writeFileSync(path.join(skillsRoot, 'manifest.json'), '{"skills":[]}\n');
+      process.env[CLAUDE_3P_SKILLS_ROOT_ENV] = skillsRoot;
+
+      const result = await installer.installForAgent(sourceDir, 'test-skill', 'claude-cowork-3p', {
+        mode: 'symlink',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.mode).toBe('copy');
+      expect(result.path).toBe(path.join(skillsRoot, 'skills', 'test-skill'));
+      expect(result.symlinkFailed).toBeUndefined();
+      expect(existsSync(path.join(result.path, 'SKILL.md'))).toBe(true);
+
+      const manifest = JSON.parse(readFileSync(path.join(skillsRoot, 'manifest.json'), 'utf-8'));
+      expect(manifest.skills[0]).toMatchObject({
+        skillId: 'test-skill',
+        name: 'test-skill',
+        enabled: true,
+      });
     });
 
     it('should fail when source does not exist', async () => {
@@ -340,6 +372,15 @@ This is test content.
       expect(cursorSkills).not.toContain('claude-skill');
       expect(claudeSkills).toContain('claude-skill');
       expect(claudeSkills).not.toContain('cursor-skill');
+    });
+
+    it('should list Claude Cowork 3P skills from its app-managed directory', async () => {
+      const skillsRoot = path.join(tempDir, 'claude-3p', 'org', 'account');
+      mkdirSync(path.join(skillsRoot, 'skills', 'test-skill'), { recursive: true });
+      writeFileSync(path.join(skillsRoot, 'manifest.json'), '{"skills":[]}\n');
+      process.env[CLAUDE_3P_SKILLS_ROOT_ENV] = skillsRoot;
+
+      expect(installer.listInstalledSkills('claude-cowork-3p')).toEqual(['test-skill']);
     });
   });
 

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -258,7 +258,7 @@ export class Installer {
    */
   getAgentSkillPath(skillName: string, agentType: AgentType): string {
     if (agentType === CLAUDE_COWORK_3P_AGENT) {
-      return getClaude3pSkillPath(sanitizeName(skillName));
+      return getClaude3pSkillPath(skillName);
     }
 
     const agent = getAgentConfig(agentType);
@@ -426,7 +426,7 @@ export class Installer {
   uninstallFromAgent(skillName: string, agentType: AgentType): boolean {
     if (agentType === CLAUDE_COWORK_3P_AGENT) {
       try {
-        return uninstallClaude3pSkill(sanitizeName(skillName));
+        return uninstallClaude3pSkill(skillName);
       } catch {
         return false;
       }

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -13,6 +13,13 @@ import { homedir, platform } from 'node:os';
 import * as path from 'node:path';
 import type { AgentType } from './agent-registry.js';
 import { getAgentConfig } from './agent-registry.js';
+import {
+  CLAUDE_COWORK_3P_AGENT,
+  getClaude3pSkillPath,
+  installClaude3pSkill,
+  listClaude3pSkills,
+  uninstallClaude3pSkill,
+} from './claude-3p-installer.js';
 import { parseSkillMd } from './skill-parser.js';
 
 /**
@@ -250,6 +257,10 @@ export class Installer {
    * Get agent's skill installation path
    */
   getAgentSkillPath(skillName: string, agentType: AgentType): string {
+    if (agentType === CLAUDE_COWORK_3P_AGENT) {
+      return getClaude3pSkillPath(sanitizeName(skillName));
+    }
+
     const agent = getAgentConfig(agentType);
     const sanitized = sanitizeName(skillName);
     const agentBase = this.isGlobal ? agent.globalSkillsDir : path.join(this.cwd, agent.skillsDir);
@@ -270,6 +281,10 @@ export class Installer {
     agentType: AgentType,
     options: { mode?: InstallMode } = {},
   ): Promise<InstallResult> {
+    if (agentType === CLAUDE_COWORK_3P_AGENT) {
+      return installClaude3pSkill(sourcePath, skillName, { mode: options.mode });
+    }
+
     const agent = getAgentConfig(agentType);
     const installMode = options.mode || 'symlink';
     const sanitized = sanitizeName(skillName);
@@ -389,8 +404,12 @@ export class Installer {
    * Check if skill is installed to specified agent
    */
   isInstalled(skillName: string, agentType: AgentType): boolean {
-    const skillPath = this.getAgentSkillPath(skillName, agentType);
-    return fs.existsSync(skillPath);
+    try {
+      const skillPath = this.getAgentSkillPath(skillName, agentType);
+      return fs.existsSync(skillPath);
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -405,6 +424,14 @@ export class Installer {
    * Uninstall skill from specified agent
    */
   uninstallFromAgent(skillName: string, agentType: AgentType): boolean {
+    if (agentType === CLAUDE_COWORK_3P_AGENT) {
+      try {
+        return uninstallClaude3pSkill(sanitizeName(skillName));
+      } catch {
+        return false;
+      }
+    }
+
     const skillPath = this.getAgentSkillPath(skillName, agentType);
 
     if (!fs.existsSync(skillPath)) {
@@ -444,6 +471,14 @@ export class Installer {
    * Get all skills installed to specified agent
    */
   listInstalledSkills(agentType: AgentType): string[] {
+    if (agentType === CLAUDE_COWORK_3P_AGENT) {
+      try {
+        return listClaude3pSkills();
+      } catch {
+        return [];
+      }
+    }
+
     const agent = getAgentConfig(agentType);
     const skillsDir = this.isGlobal ? agent.globalSkillsDir : path.join(this.cwd, agent.skillsDir);
 

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -390,16 +390,21 @@ description: Test skill
       it('should return all agent types', () => {
         const types = skillManager.getAllAgentTypes();
         expect(Array.isArray(types)).toBe(true);
-        expect(types.length).toBe(17);
+        expect(types.length).toBe(18);
         expect(types).toContain('cursor');
         expect(types).toContain('claude-code');
+        expect(types).toContain('claude-cowork-3p');
       });
     });
 
     describe('validateAgentTypes', () => {
       it('should validate correct agent types', () => {
-        const result = skillManager.validateAgentTypes(['cursor', 'claude-code']);
-        expect(result.valid).toEqual(['cursor', 'claude-code']);
+        const result = skillManager.validateAgentTypes([
+          'cursor',
+          'claude-code',
+          'claude-cowork-3p',
+        ]);
+        expect(result.valid).toEqual(['cursor', 'claude-code', 'claude-cowork-3p']);
         expect(result.invalid).toEqual([]);
       });
 
@@ -601,9 +606,7 @@ description: ${s.description}
   describe('detectSkillsInRef', () => {
     let repoDir: string;
 
-    function createLocalRepo(
-      structure: 'single' | 'multi' | 'empty',
-    ): string {
+    function createLocalRepo(structure: 'single' | 'multi' | 'empty'): string {
       const repoPath = path.join(repoDir, `detect-${structure}-repo`);
       fs.mkdirSync(repoPath, { recursive: true });
 
@@ -1598,7 +1601,12 @@ describe('SkillManager installToAgentsFromRegistry with source_type', () => {
           'installToAgentsFromGit',
         )
         .mockResolvedValue({
-          skill: { name: 'github-with-oss', path: '/tmp/skill', version: '1.0.0', source: 'github' },
+          skill: {
+            name: 'github-with-oss',
+            path: '/tmp/skill',
+            version: '1.0.0',
+            source: 'github',
+          },
           results: new Map([['cursor', { success: true, path: '/tmp', mode: 'symlink' }]]),
         });
 

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -19,11 +19,11 @@ import {
 import { parseGitUrl } from '../utils/git.js';
 import { logger } from '../utils/logger.js';
 import {
-  type ScopeRegistries,
   getRegistryUrl,
   getScopeForRegistry,
   getShortName,
   parseSkillIdentifier,
+  type ScopeRegistries,
 } from '../utils/registry-scope.js';
 import {
   type AgentType,
@@ -32,6 +32,7 @@ import {
   isValidAgentType,
 } from './agent-registry.js';
 import { CacheManager } from './cache-manager.js';
+import { CLAUDE_COWORK_3P_AGENT, getClaude3pSkillPath } from './claude-3p-installer.js';
 import { ConfigLoader, DEFAULT_REGISTRIES } from './config-loader.js';
 import { GitResolver } from './git-resolver.js';
 import { HttpResolver } from './http-resolver.js';
@@ -751,6 +752,17 @@ export class SkillManager {
     const canonicalDir = this.getCanonicalSkillsDir();
     const installed: AgentType[] = [];
     for (const [type, config] of Object.entries(agents)) {
+      if (type === CLAUDE_COWORK_3P_AGENT) {
+        try {
+          if (exists(getClaude3pSkillPath(skillName))) {
+            installed.push(type as AgentType);
+          }
+        } catch {
+          // Claude Cowork 3P keeps skills under an app-managed account directory.
+        }
+        continue;
+      }
+
       const agentBase = this.isGlobal
         ? config.globalSkillsDir
         : path.join(this.projectRoot, config.skillsDir);
@@ -921,10 +933,7 @@ export class SkillManager {
    */
   async detectSkillsInRef(
     ref: string,
-  ): Promise<
-    | { type: 'single' }
-    | { type: 'multi'; skills: ParsedSkillWithPath[] }
-  > {
+  ): Promise<{ type: 'single' } | { type: 'multi'; skills: ParsedSkillWithPath[] }> {
     // Only Git refs can be multi-skill directories
     if (this.isRegistrySource(ref) || this.isHttpSource(ref)) {
       return { type: 'single' };
@@ -1378,8 +1387,9 @@ export class SkillManager {
     // regardless of source_type. Legacy web-published skills without artifacts fall back
     // to git clone / HTTP download via installFromWebPublished.
     const sourceType = skillInfo.source_type;
-    const hasArtifacts = !!skillInfo.latest_version
-      || (Array.isArray(skillInfo.dist_tags) && skillInfo.dist_tags.length > 0);
+    const hasArtifacts =
+      !!skillInfo.latest_version ||
+      (Array.isArray(skillInfo.dist_tags) && skillInfo.dist_tags.length > 0);
 
     if (sourceType && sourceType !== 'registry' && !hasArtifacts) {
       // Legacy web-published skill without OSS artifacts → use git/http resolver

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
  * reskill - AI Skills Package Manager
  *
  * Git-based skills management for AI agents
- * Supports 17+ coding agents: Cursor, Claude Code, GitHub Copilot, etc.
+ * Supports 18+ coding agents: Cursor, Claude Code, Claude Cowork 3P, GitHub Copilot, etc.
  */
 
 // Core exports


### PR DESCRIPTION
## Summary

- Add experimental `claude-cowork-3p` agent support for app-managed Claude Cowork 3P skills roots.
- Install, list, uninstall, and detect skills under `Claude-3p/local-agent-mode-sessions/skills-plugin/<org>/<account>` with `manifest.json` updates.
- Harden path handling for 3P skill IDs, rollback file changes when manifest updates fail, prune manifest backups, and report 3P installs as copy mode.
- Document Claude Cowork 3P as Beta and add a minor changeset.

## Validation

```bash
pnpm vitest run src/core/claude-3p-installer.test.ts src/core/installer.test.ts src/core/agent-registry.test.ts
pnpm typecheck
pnpm test:run
pnpm build
pnpm biome check src/core/claude-3p-installer.ts src/core/claude-3p-installer.test.ts src/core/agent-registry.ts src/core/installer.test.ts README.md README.zh-CN.md
```

## Notes

`AGENTS.md` is intentionally left untracked and is not part of this PR.
