### PR TITLE
fix(install): --all targets detected agents only

### DIFF
--- a/.changeset/install-all-detect-agents.md
+++ b/.changeset/install-all-detect-agents.md
@@ -1,0 +1,9 @@
+---
+"reskill": patch
+---
+
+Fix `install --all` to target only detected agents instead of all 18 known agent types. On machines where platform-specific agents are unavailable (e.g. Claude Cowork 3P on Linux), the previous behavior produced guaranteed failures like "Claude Cowork 3P skills root not found". `--all` now runs agent detection first and falls back to all known agent types only when nothing is detected.
+
+---
+
+修复 `install --all` 只安装到检测到的 Agent，而不是全部 18 种已知 Agent 类型。在某些 Agent 不可用的环境下（例如 Linux 上没有 Claude Cowork 3P），原先行为会必然失败并报出 "Claude Cowork 3P skills root not found"。`--all` 现在会先做 Agent 检测，只有全部没检测到时才回退到所有已知 Agent 类型。

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npx reskill@latest <command>  # Or use npx directly
 | `-g, --global`            | `install`, `uninstall`, `list`                                | Install/manage skills globally (user directory)               |
 | `-a, --agent <agents...>` | `install`                                                     | Specify target agents (e.g., `cursor`, `claude-code`)         |
 | `--mode <mode>`           | `install`                                                     | Installation mode: `symlink` (default) or `copy`              |
-| `--all`                   | `install`                                                     | Install to all agents                                          |
+| `--all`                   | `install`                                                     | Install to all detected agents                                 |
 | `-y, --yes`               | `install`, `uninstall`, `publish`                             | Skip confirmation prompts                                      |
 | `-f, --force`             | `install`                                                     | Force reinstall even if already installed                      |
 | `-s, --skill <names...>`  | `install`                                                     | Select specific skill(s) by name from a multi-skill repo      |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,7 +71,7 @@ npx reskill@latest <command>  # 或直接使用 npx
 | `-g, --global`            | `install`, `uninstall`, `list`                                | 全局安装/管理技能（用户目录）                |
 | `-a, --agent <agents...>` | `install`                                                     | 指定目标 Agent（如 `cursor`, `claude-code`） |
 | `--mode <mode>`           | `install`                                                     | 安装模式：`symlink`（默认）或 `copy`         |
-| `--all`                   | `install`                                                     | 安装到所有 Agent                             |
+| `--all`                   | `install`                                                     | 安装到所有检测到的 Agent                     |
 | `-y, --yes`               | `install`, `uninstall`, `publish`                             | 跳过确认提示                                 |
 | `-f, --force`             | `install`                                                     | 强制重新安装                                 |
 | `-s, --skill <names...>`  | `install`                                                     | 从多 skill 仓库中选择指定 skill              |

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -153,7 +153,7 @@ reskill install github:user/skill1 github:user/skill2@v1.0.0 gitlab:team/skill3
 | `-a, --agent <agents...>` | auto-detect | Specify target agents |
 | `--mode <mode>` | `symlink` | Installation mode: `symlink` or `copy` |
 | `-y, --yes` | `false` | Skip confirmation prompts |
-| `--all` | `false` | Install to all agents (implies `-y -g`) |
+| `--all` | `false` | Install to all detected agents (implies `-y -g`). Falls back to all known agents if none are detected. |
 | `-s, --skill <names...>` | - | Select specific skill(s) by name from a multi-skill repository (Git/HTTP only) |
 | `--list` | `false` | With a single repo ref: list available skills in the repository without installing |
 | `-r, --registry <url>` | - | Registry URL override for registry-based installs |
@@ -182,7 +182,7 @@ Skill discovery scans the cached repo for `SKILL.md` files (priority dirs: `skil
 
 ### Agent Resolution Priority
 
-1. `--all` flag → install to all known agents
+1. `--all` flag → install to all detected agents; falls back to all known agents only when none are detected
 2. `-a, --agent` flag → use specified agents
 3. Reinstall all (no skill arg) + stored agents → use saved `targetAgents`
 4. Auto-detect installed agents → prompt if multiple

--- a/docs/install-formats-summary.md
+++ b/docs/install-formats-summary.md
@@ -353,7 +353,7 @@ reskill install <skill> [options]
   -a, --agent <agents>  指定目标 agent（如 cursor, claude-code）
   --mode <mode>         安装模式：symlink 或 copy
   -y, --yes             跳过确认提示
-  --all                 安装到所有 agent
+  --all                 安装到所有检测到的 agent
 ```
 
 ---

--- a/skills/reskill-usage/SKILL.md
+++ b/skills/reskill-usage/SKILL.md
@@ -98,7 +98,7 @@ Run `reskill <command> --help` for complete options and detailed usage.
 | `-g, --global`            | `install`, `uninstall`, `list`                                | Install/manage skills globally (user directory)               |
 | `-a, --agent <agents...>` | `install`                                                     | Specify target agents (e.g., `cursor`, `claude-code`)         |
 | `--mode <mode>`           | `install`                                                     | Installation mode: `symlink` (default) or `copy`              |
-| `--all`                   | `install`                                                     | Install to all agents                                         |
+| `--all`                   | `install`                                                     | Install to all detected agents                                |
 | `-y, --yes`               | `install`, `uninstall`, `publish`                             | Skip confirmation prompts                                     |
 | `-f, --force`             | `install`                                                     | Force reinstall even if already installed                     |
 | `-s, --skill <names...>`  | `install`                                                     | Select specific skill(s) by name from a multi-skill repo      |

--- a/src/cli/commands/completion.ts
+++ b/src/cli/commands/completion.ts
@@ -120,7 +120,7 @@ function handleCompletion(): void {
         { name: '--agent', description: 'Specify target agents' },
         { name: '-y', description: 'Skip confirmation' },
         { name: '--yes', description: 'Skip confirmation' },
-        { name: '--all', description: 'Install to all agents' },
+        { name: '--all', description: 'Install to all detected agents' },
       ];
       tabtab.log(options);
       return;

--- a/src/cli/commands/install-all-detection.test.ts
+++ b/src/cli/commands/install-all-detection.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the `--all` flag behavior.
+ *
+ * `--all` must install only to agents that are actually detected on the
+ * current machine. Platform-specific agents that are not present (e.g.
+ * Claude Cowork 3P on Linux) must not appear in the target list, otherwise
+ * they produce guaranteed "skills root not found" failures.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type AgentName = 'cursor' | 'claude-code' | 'windsurf' | 'claude-cowork-3p';
+
+const AGENT_CONFIGS = {
+  cursor: { name: 'cursor', displayName: 'Cursor', skillsDir: '.cursor/skills' },
+  'claude-code': { name: 'claude-code', displayName: 'Claude Code', skillsDir: '.claude/skills' },
+  windsurf: { name: 'windsurf', displayName: 'Windsurf', skillsDir: '.windsurf/skills' },
+  'claude-cowork-3p': {
+    name: 'claude-cowork-3p',
+    displayName: 'Claude Cowork 3P',
+    skillsDir: '.claude-3p/skills',
+  },
+} as const;
+
+const installToAgentsMock = vi.fn();
+const detectInstalledAgentsMock = vi.fn();
+
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    message: vi.fn(),
+    step: vi.fn(),
+  },
+  note: vi.fn(),
+  confirm: vi.fn(() => Promise.resolve(true)),
+  select: vi.fn(() => Promise.resolve('symlink')),
+  multiselect: vi.fn(() => Promise.resolve(['cursor', 'claude-code'])),
+  isCancel: vi.fn(() => false),
+  cancel: vi.fn(),
+}));
+
+vi.mock('../../core/agent-registry.js', () => ({
+  agents: AGENT_CONFIGS,
+  detectInstalledAgents: detectInstalledAgentsMock,
+  isValidAgentType: vi.fn((a: string) => a in AGENT_CONFIGS),
+  getAgentConfig: vi.fn((a: AgentName) => AGENT_CONFIGS[a]),
+}));
+
+vi.mock('../../core/auth-manager.js', () => ({
+  AuthManager: vi.fn().mockImplementation(() => ({
+    getToken: vi.fn(() => undefined),
+  })),
+}));
+
+vi.mock('../../core/config-loader.js', () => ({
+  ConfigLoader: vi.fn().mockImplementation(() => ({
+    exists: vi.fn(() => false),
+    getSkills: vi.fn(() => ({})),
+    getDefaults: vi.fn(() => ({
+      registry: 'github',
+      installDir: '.skills',
+      targetAgents: [],
+      installMode: undefined,
+    })),
+    updateDefaults: vi.fn(),
+    reload: vi.fn(),
+  })),
+}));
+
+vi.mock('../../core/skill-manager.js', () => ({
+  SkillManager: vi.fn().mockImplementation(() => ({
+    detectSkillsInRef: vi.fn().mockResolvedValue({ type: 'single' }),
+    installToAgents: installToAgentsMock,
+  })),
+}));
+
+vi.mock('../../utils/fs.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/fs.js')>('../../utils/fs.js');
+  return { ...actual, shortenPath: vi.fn((p: string) => p) };
+});
+
+function mockInstallResults(agents: AgentName[]) {
+  return new Map(
+    agents.map((a) => [
+      a,
+      { success: true, path: `/tmp/.${a}/skills/x`, mode: 'symlink' as const },
+    ]),
+  );
+}
+
+describe('install --all detection behavior', () => {
+  let originalExit: typeof process.exit;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalExit = process.exit;
+    // Stub exit so that any error path inside the command does not terminate
+    // the test runner. We assert on what was passed to installToAgents before
+    // exit would have been called.
+    process.exit = ((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as typeof process.exit;
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+  });
+
+  it('only installs to detected agents (skips agents not present on this machine)', async () => {
+    // Simulate a Linux machine where Claude Cowork 3P is not installed.
+    detectInstalledAgentsMock.mockResolvedValue(['cursor', 'claude-code']);
+    installToAgentsMock.mockResolvedValue({
+      skill: { name: 'x', version: '1.0.0' },
+      results: mockInstallResults(['cursor', 'claude-code']),
+    });
+
+    const { installCommand } = await import('./install.js');
+
+    await installCommand.parseAsync(['test-skill', '--all'], { from: 'user' });
+
+    expect(detectInstalledAgentsMock).toHaveBeenCalled();
+    expect(installToAgentsMock).toHaveBeenCalledTimes(1);
+
+    const [, targetAgents] = installToAgentsMock.mock.calls[0];
+    expect(targetAgents).toEqual(['cursor', 'claude-code']);
+    // The unavailable agent must not leak into the target list.
+    expect(targetAgents).not.toContain('claude-cowork-3p');
+    expect(targetAgents).not.toContain('windsurf');
+  });
+
+  it('falls back to all known agent types when nothing is detected', async () => {
+    detectInstalledAgentsMock.mockResolvedValue([]);
+    installToAgentsMock.mockResolvedValue({
+      skill: { name: 'x', version: '1.0.0' },
+      results: mockInstallResults([
+        'cursor',
+        'claude-code',
+        'windsurf',
+        'claude-cowork-3p',
+      ]),
+    });
+
+    const { installCommand } = await import('./install.js');
+
+    await installCommand.parseAsync(['test-skill', '--all'], { from: 'user' });
+
+    expect(detectInstalledAgentsMock).toHaveBeenCalled();
+    const [, targetAgents] = installToAgentsMock.mock.calls[0];
+    // Fallback: every agent registered in the mocked registry.
+    expect(new Set(targetAgents)).toEqual(
+      new Set(['cursor', 'claude-code', 'windsurf', 'claude-cowork-3p']),
+    );
+  });
+
+  it('surfaces detection errors and does not install', async () => {
+    detectInstalledAgentsMock.mockRejectedValue(new Error('boom'));
+
+    const { installCommand } = await import('./install.js');
+
+    // Detection failure must abort the command before any install attempt.
+    // parseAsync is wrapped in a try/catch in install.ts that calls
+    // process.exit(1), which our stub re-throws.
+    await expect(
+      installCommand.parseAsync(['test-skill', '--all'], { from: 'user' }),
+    ).rejects.toThrow(/process\.exit\(1\)/);
+
+    expect(detectInstalledAgentsMock).toHaveBeenCalled();
+    expect(installToAgentsMock).not.toHaveBeenCalled();
+  });
+
+  it('installs to the single detected agent without prompting', async () => {
+    // Only Cursor is installed — --all must pick exactly that one.
+    detectInstalledAgentsMock.mockResolvedValue(['cursor']);
+    installToAgentsMock.mockResolvedValue({
+      skill: { name: 'x', version: '1.0.0' },
+      results: mockInstallResults(['cursor']),
+    });
+
+    const { installCommand } = await import('./install.js');
+
+    await installCommand.parseAsync(['test-skill', '--all'], { from: 'user' });
+
+    const [, targetAgents] = installToAgentsMock.mock.calls[0];
+    expect(targetAgents).toEqual(['cursor']);
+  });
+});

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -128,10 +128,28 @@ async function resolveTargetAgents(
 ): Promise<AgentType[]> {
   const { options, allAgentTypes, storedAgents, hasStoredAgents, isReinstallAll } = ctx;
 
-  // Priority 1: --all flag
+  // Priority 1: --all flag — install to every detected agent on this machine.
+  // Falls back to all known agent types only when nothing is detected, so that
+  // agents that cannot exist on the current platform (e.g. Claude Cowork 3P on
+  // Linux) are skipped instead of producing guaranteed failures.
   if (options.all) {
-    p.log.info(`Installing to all ${chalk.cyan(allAgentTypes.length)} agents`);
-    return allAgentTypes;
+    spinner.start('Detecting installed agents...');
+    const installedAgents = await detectInstalledAgents();
+    spinner.stop(
+      `Detected ${chalk.green(installedAgents.length)} agent${installedAgents.length !== 1 ? 's' : ''}`,
+    );
+
+    if (installedAgents.length === 0) {
+      p.log.info(
+        `No agents detected, installing to all ${chalk.cyan(allAgentTypes.length)} known agents`,
+      );
+      return allAgentTypes;
+    }
+
+    p.log.info(
+      `Installing to ${chalk.cyan(installedAgents.length)} detected agent(s): ${formatAgentNames(installedAgents)}`,
+    );
+    return installedAgents;
   }
 
   // Priority 2: -a/--agent flag
@@ -184,7 +202,7 @@ async function detectAndPromptAgents(
   // No agents detected
   if (installedAgents.length === 0) {
     if (skipConfirm) {
-      p.log.info('Installing to all agents (none detected)');
+      p.log.info('Installing to all known agents (none detected)');
       return allAgentTypes;
     }
     return await promptAgentSelection(
@@ -960,7 +978,7 @@ export const installCommand = new Command('install')
   .option('-a, --agent <agents...>', 'Specify target agents (e.g., cursor, claude-code)')
   .option('--mode <mode>', 'Installation mode: symlink or copy')
   .option('-y, --yes', 'Skip confirmation prompts')
-  .option('--all', 'Install to all agents (implies -y -g)')
+  .option('--all', 'Install to all detected agents (implies -y -g)')
   .option(
     '-s, --skill <names...>',
     'Select specific skill(s) by name from a multi-skill repository',


### PR DESCRIPTION
## Summary

- `install --all` now installs only to agents detected on the current machine, instead of blindly fanning out to all 18 known agent types
- Fixes the Linux dev-box failure `Claude Cowork 3P skills root not found under /root/.config/Claude-3p/...` that happens because `claude-cowork-3p` can only exist on macOS
- Falls back to all known agent types when detection returns zero, preserving the old behavior for environments where nothing is detectable (e.g. clean CI)
- Synced wording across CLI help, tab-completion hints, README (EN + 中文), `docs/cli-spec.md`, `docs/install-formats-summary.md`, and `skills/reskill-usage/SKILL.md`
- Added `install-all-detection.test.ts` covering: detect → subset install, empty detect → fallback, single detect, detection errors abort without installing (`process.exit(1)` and `installToAgents` never called)

## Behavior

| Scenario | Before | After |
|---|---|---|
| Linux, only `claude-code` installed | installs to 18 types, Claude Cowork 3P fails | installs to `claude-code` only |
| macOS, 3 agents installed | installs to 18 types, 15 are noise | installs to those 3 |
| Clean container, nothing detected | installs to 18 types | falls back to 18 types (unchanged) |
| `detectInstalledAgents()` throws | crash inside targeting | error surfaces, no install |

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm vitest run src/cli/commands/install-all-detection.test.ts src/cli/commands/install.test.ts src/cli/commands/uninstall.test.ts` — 75 tests pass
- [x] Anti-regression check: reverting the Priority-1 branch makes all 4 new tests fail; restoring makes them pass — confirms the tests actually guard the fix
- [ ] Manual verification on Linux: `npx reskill install @kanyun/badou-group-messages --all --force` no longer reports "skills root not found" for Claude Cowork 3P

🤖 Generated with [Claude Code](https://claude.com/claude-code)