### PR TITLE
fix(core): treat claude-cowork-3p installs as effectively global

### DIFF
--- a/.changeset/fix-claude-3p-global-install.md
+++ b/.changeset/fix-claude-3p-global-install.md
@@ -1,0 +1,13 @@
+---
+"reskill": patch
+---
+
+Fix: treat claude-cowork-3p installations as effectively global
+
+When installing skills exclusively to `claude-cowork-3p` agent (without `--global` flag), the installation was incorrectly writing to project-level `skills.json` and `skills.lock`. Since claude-cowork-3p always installs to a global app-managed directory, these writes are now skipped unless other non-global agents are also targeted.
+
+---
+
+修复：将 claude-cowork-3p 安装视为等效全局安装
+
+当仅安装 skill 到 `claude-cowork-3p` agent（未传 `--global`）时，之前会错误地写入项目级别的 `skills.json` 和 `skills.lock`。由于 claude-cowork-3p 始终安装到全局的应用管理目录，现在除非同时涉及其他非全局 agent，否则跳过这些写入。

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -263,6 +263,13 @@ async function resolveInstallScope(
     return options.global;
   }
 
+  // Skip prompt for reinstall-all (always project scope).
+  // Must be checked before the claude-cowork-3p override to avoid
+  // "Cannot install all skills globally" when 3p is the only detected agent.
+  if (isReinstallAll) {
+    return false;
+  }
+
   // claude-cowork-3p always installs globally — skip prompt
   if (
     targetAgents.length > 0 &&
@@ -270,11 +277,6 @@ async function resolveInstallScope(
   ) {
     p.log.info('Using global scope (claude-cowork-3p is always global)');
     return true;
-  }
-
-  // Skip prompt for reinstall-all (always project scope)
-  if (isReinstallAll) {
-    return false;
   }
 
   // Skip prompt if --yes

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import { type AgentType, agents, detectInstalledAgents } from '../../core/agent-registry.js';
 import { AuthManager } from '../../core/auth-manager.js';
+import { CLAUDE_COWORK_3P_AGENT } from '../../core/claude-3p-installer.js';
 import { ConfigLoader } from '../../core/config-loader.js';
 import type { InstallMode } from '../../core/installer.js';
 import { SkillManager } from '../../core/skill-manager.js';
@@ -251,12 +252,24 @@ async function promptAgentSelection(
 /**
  * Resolve installation scope (global vs project)
  */
-async function resolveInstallScope(ctx: InstallContext): Promise<boolean> {
+async function resolveInstallScope(
+  ctx: InstallContext,
+  targetAgents: AgentType[],
+): Promise<boolean> {
   const { options, isReinstallAll, skipConfirm } = ctx;
 
   // Explicit --global flag
   if (options.global !== undefined) {
     return options.global;
+  }
+
+  // claude-cowork-3p always installs globally — skip prompt
+  if (
+    targetAgents.length > 0 &&
+    targetAgents.every((a) => a === CLAUDE_COWORK_3P_AGENT)
+  ) {
+    p.log.info('Using global scope (claude-cowork-3p is always global)');
+    return true;
   }
 
   // Skip prompt for reinstall-all (always project scope)
@@ -301,12 +314,23 @@ async function resolveInstallScope(ctx: InstallContext): Promise<boolean> {
 /**
  * Resolve installation mode (symlink vs copy)
  */
-async function resolveInstallMode(ctx: InstallContext): Promise<InstallMode> {
+async function resolveInstallMode(
+  ctx: InstallContext,
+  targetAgents: AgentType[],
+): Promise<InstallMode> {
   const { options, storedMode, isReinstallAll, skipConfirm } = ctx;
 
   // Priority 1: CLI --mode option
   if (options.mode) {
     return options.mode;
+  }
+
+  // claude-cowork-3p always uses copy mode — skip prompt
+  if (
+    targetAgents.length > 0 &&
+    targetAgents.every((a) => a === CLAUDE_COWORK_3P_AGENT)
+  ) {
+    return 'copy';
   }
 
   // Priority 2: Reinstall all with stored mode
@@ -1026,7 +1050,7 @@ export const installCommand = new Command('install')
         targetAgents = await resolveTargetAgents(ctx, spinner);
 
         // Step 2: Resolve installation scope
-        installGlobally = await resolveInstallScope(ctx);
+        installGlobally = await resolveInstallScope(ctx, targetAgents);
 
         // Validate: Cannot install all skills globally
         if (ctx.isReinstallAll && installGlobally) {
@@ -1035,7 +1059,7 @@ export const installCommand = new Command('install')
         }
 
         // Step 3: Resolve installation mode
-        installMode = await resolveInstallMode(ctx);
+        installMode = await resolveInstallMode(ctx, targetAgents);
       }
 
       // Step 4: Execute installation

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -2849,7 +2849,7 @@ describe('SkillManager isEffectivelyGlobal behavior for claude-cowork-3p', () =>
     expect(lock.skills['test-skill']).toBeDefined();
   });
 
-  it('should modify skills.json/skills.lock when uninstalling from mixed agents including non-3p', () => {
+  it('should modify skills.json/skills.lock when uninstalling from a non-3p agent', () => {
     // Setup: Create skills.json and skills.lock
     fs.writeFileSync(
       path.join(tempDir, 'skills.json'),
@@ -2886,9 +2886,9 @@ describe('SkillManager isEffectivelyGlobal behavior for claude-cowork-3p', () =>
   it('should NOT write skills.json/skills.lock when installing to only claude-cowork-3p', async () => {
     // Note: This test mocks installToAgentsFromGit entirely, so it only verifies
     // the dispatch path (installToAgents delegates to the private method without
-    // any manifest writes of its own). The manifest-write guard inside
-    // installToAgentsFromGit is covered by the uninstall tests below which
-    // exercise the real isEffectivelyGlobal logic without network dependencies.
+    // any manifest writes of its own). The isEffectivelyGlobal method itself is
+    // exercised by the uninstall tests below, which verify the core logic without
+    // network dependencies.
     const mockResult = {
       skill: {
         name: 'test-skill',
@@ -2914,7 +2914,7 @@ describe('SkillManager isEffectivelyGlobal behavior for claude-cowork-3p', () =>
     expect(fs.existsSync(path.join(tempDir, 'skills.lock'))).toBe(false);
   });
 
-  it('should modify skills.json/skills.lock when uninstalling from mixed agents including non-3p', () => {
+  it('should modify skills.json/skills.lock when uninstalling from both claude-cowork-3p and non-3p agents', () => {
     // Simulates: reskill uninstall test-skill -a claude-cowork-3p cursor
     // Mixed agents include a non-3p agent, so manifest SHOULD be updated.
     fs.writeFileSync(

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -2884,7 +2884,11 @@ describe('SkillManager isEffectivelyGlobal behavior for claude-cowork-3p', () =>
   });
 
   it('should NOT write skills.json/skills.lock when installing to only claude-cowork-3p', async () => {
-    // Setup: mock internal installToAgentsFromGit to avoid network calls
+    // Note: This test mocks installToAgentsFromGit entirely, so it only verifies
+    // the dispatch path (installToAgents delegates to the private method without
+    // any manifest writes of its own). The manifest-write guard inside
+    // installToAgentsFromGit is covered by the uninstall tests below which
+    // exercise the real isEffectivelyGlobal logic without network dependencies.
     const mockResult = {
       skill: {
         name: 'test-skill',
@@ -2910,10 +2914,9 @@ describe('SkillManager isEffectivelyGlobal behavior for claude-cowork-3p', () =>
     expect(fs.existsSync(path.join(tempDir, 'skills.lock'))).toBe(false);
   });
 
-  it('should NOT modify skills.json/skills.lock when uninstalling from mixed agents with only claude-cowork-3p', () => {
+  it('should modify skills.json/skills.lock when uninstalling from mixed agents including non-3p', () => {
     // Simulates: reskill uninstall test-skill -a claude-cowork-3p cursor
-    // where both agents are specified but the key question is whether manifest is updated.
-    // Since the array contains a non-3p agent (cursor), manifest SHOULD be updated.
+    // Mixed agents include a non-3p agent, so manifest SHOULD be updated.
     fs.writeFileSync(
       path.join(tempDir, 'skills.json'),
       JSON.stringify({ skills: { 'test-skill': 'github:user/test-skill@v1.0.0' } }),

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -2910,31 +2910,40 @@ describe('SkillManager isEffectivelyGlobal behavior for claude-cowork-3p', () =>
     expect(fs.existsSync(path.join(tempDir, 'skills.lock'))).toBe(false);
   });
 
-  it('should write skills.json/skills.lock when installing to cursor agent', async () => {
-    // Setup: mock internal installToAgentsFromGit
-    const mockResult = {
-      skill: {
-        name: 'test-skill',
-        path: '/tmp/skill',
-        version: '1.0.0',
-        source: 'github:user/test-skill',
-      },
-      results: new Map([['cursor', { success: true, path: '/tmp', mode: 'symlink' as const }]]),
-    };
+  it('should NOT modify skills.json/skills.lock when uninstalling from mixed agents with only claude-cowork-3p', () => {
+    // Simulates: reskill uninstall test-skill -a claude-cowork-3p cursor
+    // where both agents are specified but the key question is whether manifest is updated.
+    // Since the array contains a non-3p agent (cursor), manifest SHOULD be updated.
+    fs.writeFileSync(
+      path.join(tempDir, 'skills.json'),
+      JSON.stringify({ skills: { 'test-skill': 'github:user/test-skill@v1.0.0' } }),
+    );
+    fs.writeFileSync(
+      path.join(tempDir, 'skills.lock'),
+      JSON.stringify({
+        lockfileVersion: 1,
+        skills: {
+          'test-skill': {
+            source: 'github:user/test-skill',
+            version: '1.0.0',
+            ref: 'v1.0.0',
+            resolved: 'https://github.com/user/test-skill.git',
+            commit: 'abc123',
+            installedAt: new Date().toISOString(),
+          },
+        },
+      }),
+    );
 
-    vi.spyOn(
-      manager as unknown as Record<string, (...args: unknown[]) => unknown>,
-      'installToAgentsFromGit',
-    ).mockResolvedValue(mockResult);
+    // Action: Uninstall targeting both claude-cowork-3p and cursor
+    manager.uninstallFromAgents('test-skill', ['claude-cowork-3p', 'cursor']);
 
-    // Action: Install targeting cursor
-    await manager.installToAgents('github:user/test-skill@v1.0.0', ['cursor']);
+    // Assert: skills.json and skills.lock should be updated (cursor is non-global)
+    const config = JSON.parse(fs.readFileSync(path.join(tempDir, 'skills.json'), 'utf-8'));
+    expect(config.skills['test-skill']).toBeUndefined();
 
-    // Assert: The mock resolves before lock/config writes happen in the actual
-    // installToAgentsFromGit, so we are testing that the public installToAgents
-    // delegates correctly. The mock bypasses internal logic, so this test verifies
-    // the routing, not the write behavior (which is covered by uninstall tests above).
-    expect(mockResult.results.get('cursor')?.success).toBe(true);
+    const lock = JSON.parse(fs.readFileSync(path.join(tempDir, 'skills.lock'), 'utf-8'));
+    expect(lock.skills['test-skill']).toBeUndefined();
   });
 });
 

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -2801,6 +2801,143 @@ describe('SkillManager --registry auto-save to skills.json.registries', () => {
   });
 });
 
+describe('SkillManager isEffectivelyGlobal behavior for claude-cowork-3p', () => {
+  let tempDir: string;
+  let manager: SkillManager;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reskill-effective-global-'));
+    manager = new SkillManager(tempDir);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should NOT modify skills.json/skills.lock when uninstalling from only claude-cowork-3p', () => {
+    // Setup: Create skills.json and skills.lock with an existing skill
+    fs.writeFileSync(
+      path.join(tempDir, 'skills.json'),
+      JSON.stringify({ skills: { 'test-skill': 'github:user/test-skill@v1.0.0' } }),
+    );
+    fs.writeFileSync(
+      path.join(tempDir, 'skills.lock'),
+      JSON.stringify({
+        lockfileVersion: 1,
+        skills: {
+          'test-skill': {
+            source: 'github:user/test-skill',
+            version: '1.0.0',
+            ref: 'v1.0.0',
+            resolved: 'https://github.com/user/test-skill.git',
+            commit: 'abc123',
+            installedAt: new Date().toISOString(),
+          },
+        },
+      }),
+    );
+
+    // Action: Uninstall targeting only claude-cowork-3p
+    manager.uninstallFromAgents('test-skill', ['claude-cowork-3p']);
+
+    // Assert: skills.json and skills.lock should remain unchanged
+    const config = JSON.parse(fs.readFileSync(path.join(tempDir, 'skills.json'), 'utf-8'));
+    expect(config.skills['test-skill']).toBe('github:user/test-skill@v1.0.0');
+
+    const lock = JSON.parse(fs.readFileSync(path.join(tempDir, 'skills.lock'), 'utf-8'));
+    expect(lock.skills['test-skill']).toBeDefined();
+  });
+
+  it('should modify skills.json/skills.lock when uninstalling from mixed agents including non-3p', () => {
+    // Setup: Create skills.json and skills.lock
+    fs.writeFileSync(
+      path.join(tempDir, 'skills.json'),
+      JSON.stringify({ skills: { 'test-skill': 'github:user/test-skill@v1.0.0' } }),
+    );
+    fs.writeFileSync(
+      path.join(tempDir, 'skills.lock'),
+      JSON.stringify({
+        lockfileVersion: 1,
+        skills: {
+          'test-skill': {
+            source: 'github:user/test-skill',
+            version: '1.0.0',
+            ref: 'v1.0.0',
+            resolved: 'https://github.com/user/test-skill.git',
+            commit: 'abc123',
+            installedAt: new Date().toISOString(),
+          },
+        },
+      }),
+    );
+
+    // Action: Uninstall targeting cursor (non-3p agent)
+    manager.uninstallFromAgents('test-skill', ['cursor']);
+
+    // Assert: skills.json and skills.lock should have the skill removed
+    const config = JSON.parse(fs.readFileSync(path.join(tempDir, 'skills.json'), 'utf-8'));
+    expect(config.skills['test-skill']).toBeUndefined();
+
+    const lock = JSON.parse(fs.readFileSync(path.join(tempDir, 'skills.lock'), 'utf-8'));
+    expect(lock.skills['test-skill']).toBeUndefined();
+  });
+
+  it('should NOT write skills.json/skills.lock when installing to only claude-cowork-3p', async () => {
+    // Setup: mock internal installToAgentsFromGit to avoid network calls
+    const mockResult = {
+      skill: {
+        name: 'test-skill',
+        path: '/tmp/skill',
+        version: '1.0.0',
+        source: 'github:user/test-skill',
+      },
+      results: new Map([
+        ['claude-cowork-3p', { success: true, path: '/tmp', mode: 'copy' as const }],
+      ]),
+    };
+
+    vi.spyOn(
+      manager as unknown as Record<string, (...args: unknown[]) => unknown>,
+      'installToAgentsFromGit',
+    ).mockResolvedValue(mockResult);
+
+    // Action: Install targeting only claude-cowork-3p
+    await manager.installToAgents('github:user/test-skill@v1.0.0', ['claude-cowork-3p']);
+
+    // Assert: No skills.json or skills.lock should be created
+    expect(fs.existsSync(path.join(tempDir, 'skills.json'))).toBe(false);
+    expect(fs.existsSync(path.join(tempDir, 'skills.lock'))).toBe(false);
+  });
+
+  it('should write skills.json/skills.lock when installing to cursor agent', async () => {
+    // Setup: mock internal installToAgentsFromGit
+    const mockResult = {
+      skill: {
+        name: 'test-skill',
+        path: '/tmp/skill',
+        version: '1.0.0',
+        source: 'github:user/test-skill',
+      },
+      results: new Map([['cursor', { success: true, path: '/tmp', mode: 'symlink' as const }]]),
+    };
+
+    vi.spyOn(
+      manager as unknown as Record<string, (...args: unknown[]) => unknown>,
+      'installToAgentsFromGit',
+    ).mockResolvedValue(mockResult);
+
+    // Action: Install targeting cursor
+    await manager.installToAgents('github:user/test-skill@v1.0.0', ['cursor']);
+
+    // Assert: The mock resolves before lock/config writes happen in the actual
+    // installToAgentsFromGit, so we are testing that the public installToAgents
+    // delegates correctly. The mock bypasses internal logic, so this test verifies
+    // the routing, not the write behavior (which is covered by uninstall tests above).
+    expect(mockResult.results.get('cursor')?.success).toBe(true);
+  });
+});
+
 // Integration tests (require network)
 describe('SkillManager integration', () => {
   it.skip('should install from real repository', async () => {

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1855,13 +1855,14 @@ export class SkillManager {
 
     const results = installer.uninstallFromAgents(name, targetAgents);
 
-    // Remove from lock file (project mode only)
-    if (!this.isGlobal) {
+    // Remove from lock file (project mode only, skip for effectively-global installs)
+    const effectivelyGlobal = this.isEffectivelyGlobal(targetAgents);
+    if (!effectivelyGlobal) {
       this.lockManager.remove(name);
     }
 
-    // Remove from skills.json (project mode only)
-    if (!this.isGlobal && this.config.exists()) {
+    // Remove from skills.json (project mode only, skip for effectively-global installs)
+    if (!effectivelyGlobal && this.config.exists()) {
       this.config.removeSkill(name);
     }
 

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1601,7 +1601,8 @@ export class SkillManager {
     const optionsWithContext = { ...options, registryContext };
 
     // Save custom registry to skills.json.registries (for reinstall without lock file)
-    if (!this.isEffectivelyGlobal(targetAgents) && options.registry) {
+    const effectivelyGlobal = this.isEffectivelyGlobal(targetAgents);
+    if (!effectivelyGlobal && options.registry) {
       const registryName = this.deriveRegistryName(options.registry);
       if (registryName) {
         this.config.ensureExists();

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -117,6 +117,20 @@ export class SkillManager {
   }
 
   /**
+   * Determine if the installation is effectively global.
+   *
+   * Claude Cowork 3P always installs to a global app-managed directory regardless
+   * of the isGlobal flag. When all target agents are claude-cowork-3p, the
+   * installation should be treated as global (skip skills.json/skills.lock writes).
+   */
+  private isEffectivelyGlobal(targetAgents: AgentType[]): boolean {
+    if (this.isGlobal) return true;
+    return (
+      targetAgents.length > 0 && targetAgents.every((a) => a === CLAUDE_COWORK_3P_AGENT)
+    );
+  }
+
+  /**
    * Get project root directory
    */
   getProjectRoot(): string {
@@ -1117,7 +1131,8 @@ export class SkillManager {
         { mode: mode as InstallMode },
       );
 
-      if (!this.isGlobal) {
+      const effectivelyGlobal = this.isEffectivelyGlobal(targetAgents);
+      if (!effectivelyGlobal) {
         this.lockManager.lockSkill(skillInfo.name, {
           source: skillSource,
           version: semanticVersion,
@@ -1127,7 +1142,7 @@ export class SkillManager {
         });
       }
 
-      if (!this.isGlobal && save) {
+      if (!effectivelyGlobal && save) {
         this.config.ensureExists();
         this.config.addSkill(skillInfo.name, `${baseRefForSave}#${skillInfo.name}`);
       }
@@ -1202,8 +1217,9 @@ export class SkillManager {
       mode: mode as InstallMode,
     });
 
-    // Update lock file (project mode only)
-    if (!this.isGlobal) {
+    // Update lock file (project mode only, skip for effectively-global installs)
+    const effectivelyGlobal = this.isEffectivelyGlobal(targetAgents);
+    if (!effectivelyGlobal) {
       const lockSource =
         registryContext?.lockSource ??
         `${parsed.registry}:${parsed.owner}/${parsed.repo}${parsed.subPath ? `/${parsed.subPath}` : ''}`;
@@ -1217,8 +1233,8 @@ export class SkillManager {
       });
     }
 
-    // Update skills.json (project mode only)
-    if (!this.isGlobal && save) {
+    // Update skills.json (project mode only, skip for effectively-global installs)
+    if (!effectivelyGlobal && save) {
       this.config.ensureExists();
       const configRef = registryContext?.configRef ?? this.config.normalizeSkillRef(ref);
       this.config.addSkill(skillName, configRef);
@@ -1302,8 +1318,9 @@ export class SkillManager {
       mode: mode as InstallMode,
     });
 
-    // Update lock file (project mode only)
-    if (!this.isGlobal) {
+    // Update lock file (project mode only, skip for effectively-global installs)
+    const effectivelyGlobal = this.isEffectivelyGlobal(targetAgents);
+    if (!effectivelyGlobal) {
       const lockSource = registryContext?.lockSource ?? `http:${httpInfo.host}/${skillName}`;
       this.lockManager.lockSkill(skillName, {
         source: lockSource,
@@ -1315,8 +1332,8 @@ export class SkillManager {
       });
     }
 
-    // Update skills.json (project mode only)
-    if (!this.isGlobal && save) {
+    // Update skills.json (project mode only, skip for effectively-global installs)
+    if (!effectivelyGlobal && save) {
       this.config.ensureExists();
       const configRef = registryContext?.configRef ?? ref;
       this.config.addSkill(skillName, configRef);
@@ -1476,8 +1493,9 @@ export class SkillManager {
         mode: mode as InstallMode,
       });
 
-      // 7. Update lock file (project mode only)
-      if (!this.isGlobal) {
+      // 7. Update lock file (project mode only, skip for effectively-global installs)
+      const effectivelyGlobal = this.isEffectivelyGlobal(targetAgents);
+      if (!effectivelyGlobal) {
         this.lockManager.lockSkill(shortName, {
           source: `registry:${resolvedParsed.fullName}`,
           version,
@@ -1488,8 +1506,8 @@ export class SkillManager {
         });
       }
 
-      // 8. Update skills.json (project mode only)
-      if (!this.isGlobal && save) {
+      // 8. Update skills.json (project mode only, skip for effectively-global installs)
+      if (!effectivelyGlobal && save) {
         this.config.ensureExists();
         // Save with full name for registry skills
         this.config.addSkill(shortName, ref);
@@ -1583,7 +1601,7 @@ export class SkillManager {
     const optionsWithContext = { ...options, registryContext };
 
     // Save custom registry to skills.json.registries (for reinstall without lock file)
-    if (!this.isGlobal && options.registry) {
+    if (!this.isEffectivelyGlobal(targetAgents) && options.registry) {
       const registryName = this.deriveRegistryName(options.registry);
       if (registryName) {
         this.config.ensureExists();
@@ -1726,8 +1744,9 @@ export class SkillManager {
       const skillName = metadata?.name ?? shortName;
       const semanticVersion = metadata?.version ?? version;
 
-      // Update lock file (project mode only)
-      if (!this.isGlobal) {
+      // Update lock file (project mode only, skip for effectively-global installs)
+      const effectivelyGlobal = this.isEffectivelyGlobal(targetAgents);
+      if (!effectivelyGlobal) {
         this.lockManager.lockSkill(skillName, {
           source: `registry:${parsed.fullName}`,
           version: semanticVersion,
@@ -1738,8 +1757,8 @@ export class SkillManager {
         });
       }
 
-      // Update skills.json (project mode only)
-      if (!this.isGlobal && save) {
+      // Update skills.json (project mode only, skip for effectively-global installs)
+      if (!effectivelyGlobal && save) {
         this.config.ensureExists();
         this.config.addSkill(skillName, parsed.fullName);
 


### PR DESCRIPTION
## Summary

- Fix: installing skills with `-a claude-cowork-3p` (without `--global`) no longer writes to project-level `skills.json` and `skills.lock`
- Add `isEffectivelyGlobal()` helper that treats installations targeting only `claude-cowork-3p` as global, since that agent always installs to an app-managed global directory
- Resolves user-reported issue: skill installed via `-a claude-cowork-3p` not appearing in `reskill list --global`

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:run` — all 1501 tests pass
- [ ] Manual: `reskill install <ref> -a claude-cowork-3p` should NOT create/modify `skills.json` or `skills.lock`
- [ ] Manual: `reskill install <ref> -a claude-cowork-3p -a cursor` should still write to `skills.json`/`skills.lock` (mixed agents, not all global)

🤖 Generated with [Claude Code](https://claude.com/claude-code)