### PR TITLE
feat(cli): add -a/--agent option to list command

### DIFF
--- a/.changeset/feat-list-agent-option.md
+++ b/.changeset/feat-list-agent-option.md
@@ -1,0 +1,13 @@
+---
+"reskill": minor
+---
+
+Add `-a/--agent` option to `list` command
+
+`reskill list -a <agent>` now lists skills installed to a specific agent directory. For `claude-cowork-3p`, this implicitly uses global scope since that agent always installs to a global app-managed directory.
+
+---
+
+为 `list` 命令新增 `-a/--agent` 选项
+
+`reskill list -a <agent>` 可列出安装到指定 agent 目录的 skill。对于 `claude-cowork-3p`，会隐式使用全局作用域，因为该 agent 始终安装到全局的应用管理目录。

--- a/.changeset/feat-list-agent-option.md
+++ b/.changeset/feat-list-agent-option.md
@@ -2,12 +2,16 @@
 "reskill": minor
 ---
 
-Add `-a/--agent` option to `list` command
+Add `-a/--agent` option to `list` command and include claude-cowork-3p in global listing
 
 `reskill list -a <agent>` now lists skills installed to a specific agent directory. For `claude-cowork-3p`, this implicitly uses global scope since that agent always installs to a global app-managed directory.
 
+`reskill list --global` now also includes skills installed to claude-cowork-3p, since they are effectively global.
+
 ---
 
-为 `list` 命令新增 `-a/--agent` 选项
+为 `list` 命令新增 `-a/--agent` 选项，并在全局列表中包含 claude-cowork-3p
 
 `reskill list -a <agent>` 可列出安装到指定 agent 目录的 skill。对于 `claude-cowork-3p`，会隐式使用全局作用域，因为该 agent 始终安装到全局的应用管理目录。
+
+`reskill list --global` 现在也会列出安装到 claude-cowork-3p 的 skill，因为它们本质上是全局安装的。

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npx reskill@latest <command>  # Or use npx directly
 | ------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------- |
 | `--no-save`               | `install`                                                     | Install without saving to `skills.json` (for personal skills) |
 | `-g, --global`            | `install`, `uninstall`, `list`                                | Install/manage skills globally (user directory)               |
-| `-a, --agent <agents...>` | `install`                                                     | Specify target agents (e.g., `cursor`, `claude-code`)         |
+| `-a, --agent <agents...>` | `install`, `list`                                             | Specify target agents (e.g., `cursor`, `claude-code`)         |
 | `--mode <mode>`           | `install`                                                     | Installation mode: `symlink` (default) or `copy`              |
 | `--all`                   | `install`                                                     | Install to all agents                                          |
 | `-y, --yes`               | `install`, `uninstall`, `publish`                             | Skip confirmation prompts                                      |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ npx reskill@latest <command>  # Or use npx directly
 | ------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------- |
 | `--no-save`               | `install`                                                     | Install without saving to `skills.json` (for personal skills) |
 | `-g, --global`            | `install`, `uninstall`, `list`                                | Install/manage skills globally (user directory)               |
-| `-a, --agent <agents...>` | `install`, `list`                                             | Specify target agents (e.g., `cursor`, `claude-code`)         |
+| `-a, --agent <agents...>` | `install`                                                     | Specify target agents (e.g., `cursor`, `claude-code`)         |
+| `-a, --agent <agent>`     | `list`                                                        | List skills installed to a specific agent                     |
 | `--mode <mode>`           | `install`                                                     | Installation mode: `symlink` (default) or `copy`              |
 | `--all`                   | `install`                                                     | Install to all agents                                          |
 | `-y, --yes`               | `install`, `uninstall`, `publish`                             | Skip confirmation prompts                                      |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,7 +69,7 @@ npx reskill@latest <command>  # 或直接使用 npx
 | ------------------------- | ------------------------------------------------------------- | -------------------------------------------- |
 | `--no-save`               | `install`                                                     | 安装时不保存到 `skills.json`（用于个人技能） |
 | `-g, --global`            | `install`, `uninstall`, `list`                                | 全局安装/管理技能（用户目录）                |
-| `-a, --agent <agents...>` | `install`                                                     | 指定目标 Agent（如 `cursor`, `claude-code`） |
+| `-a, --agent <agents...>` | `install`, `list`                                             | 指定目标 Agent（如 `cursor`, `claude-code`） |
 | `--mode <mode>`           | `install`                                                     | 安装模式：`symlink`（默认）或 `copy`         |
 | `--all`                   | `install`                                                     | 安装到所有 Agent                             |
 | `-y, --yes`               | `install`, `uninstall`, `publish`                             | 跳过确认提示                                 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,7 +69,8 @@ npx reskill@latest <command>  # 或直接使用 npx
 | ------------------------- | ------------------------------------------------------------- | -------------------------------------------- |
 | `--no-save`               | `install`                                                     | 安装时不保存到 `skills.json`（用于个人技能） |
 | `-g, --global`            | `install`, `uninstall`, `list`                                | 全局安装/管理技能（用户目录）                |
-| `-a, --agent <agents...>` | `install`, `list`                                             | 指定目标 Agent（如 `cursor`, `claude-code`） |
+| `-a, --agent <agents...>` | `install`                                                     | 指定目标 Agent（如 `cursor`, `claude-code`） |
+| `-a, --agent <agent>`     | `list`                                                        | 列出安装到指定 Agent 的技能                  |
 | `--mode <mode>`           | `install`                                                     | 安装模式：`symlink`（默认）或 `copy`         |
 | `--all`                   | `install`                                                     | 安装到所有 Agent                             |
 | `-y, --yes`               | `install`, `uninstall`, `publish`                             | 跳过确认提示                                 |

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -346,14 +346,19 @@ reskill list [options]
 |--------|---------|-------------|
 | `-j, --json` | `false` | Output as JSON |
 | `-g, --global` | `false` | List globally installed skills |
+| `-a, --agent <agent>` | - | List skills installed to a specific agent |
 
 ### Behavior
 
 | Scenario | Expected Behavior | Exit Code |
 |----------|-------------------|-----------|
-| Skills exist | Display table with Name, Version, Source | `0` |
+| Skills exist | Display table with Name, Version, Source, Agents | `0` |
 | No skills | Info: "No skills installed" | `0` |
 | `--json` | Output JSON array | `0` |
+| `--global` | List globally installed skills, including claude-cowork-3p | `0` |
+| `-a <agent>` | List skills in the specified agent's directory | `0` |
+| `-a claude-cowork-3p` | List skills in Claude Cowork 3P (implicitly global) | `0` |
+| `-a <invalid>` | Error: "Invalid agent" | `1` |
 
 ### Output
 

--- a/src/cli/commands/__integration__/basic.test.ts
+++ b/src/cli/commands/__integration__/basic.test.ts
@@ -272,6 +272,46 @@ describe('CLI Integration: list', () => {
     expect(stdout).toContain('Agents');
     expect(stdout).toContain('Cursor');
   });
+
+  it('should list skills filtered by agent with -a flag', () => {
+    // Create skill in cursor agent directory
+    const cursorDir = path.join(tempDir, '.cursor', 'skills', 'cursor-skill');
+    fs.mkdirSync(cursorDir, { recursive: true });
+    fs.writeFileSync(path.join(cursorDir, 'SKILL.md'), '# Cursor Skill');
+
+    // Create skill in claude-code agent directory (should not appear)
+    const claudeDir = path.join(tempDir, '.claude', 'skills', 'claude-skill');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, 'SKILL.md'), '# Claude Skill');
+
+    const { stdout, exitCode } = runCli('list -a cursor', tempDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('cursor-skill');
+    expect(stdout).not.toContain('claude-skill');
+    expect(stdout).toContain('Cursor');
+  });
+
+  it('should show no skills message for agent with no skills', () => {
+    const { stdout, exitCode } = runCli('list -a codex', tempDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('No skills installed for Codex');
+  });
+
+  it('should exit with error for invalid agent', () => {
+    const { stderr, exitCode } = runCli('list -a invalid-agent', tempDir);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Invalid agent');
+  });
+
+  it('should show agent display name in header with -a flag', () => {
+    const cursorDir = path.join(tempDir, '.cursor', 'skills', 'my-skill');
+    fs.mkdirSync(cursorDir, { recursive: true });
+    fs.writeFileSync(path.join(cursorDir, 'SKILL.md'), '# My Skill');
+
+    const { stdout, exitCode } = runCli('list -a cursor', tempDir);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Installed Skills (Cursor)');
+  });
 });
 
 // ============================================================================

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -14,12 +14,14 @@ export const listCommand = new Command('list')
   .option('-g, --global', 'List globally installed skills')
   .option('-a, --agent <agent>', 'List skills installed to a specific agent')
   .action((options) => {
-    const agent: AgentType | undefined = options.agent;
+    const agentInput: string | undefined = options.agent;
 
-    if (agent && !isValidAgentType(agent)) {
-      logger.error(`Invalid agent: ${agent}`);
+    if (agentInput !== undefined && !isValidAgentType(agentInput)) {
+      logger.error(`Invalid agent: ${agentInput}`);
       process.exit(1);
     }
+
+    const agent = agentInput as AgentType | undefined;
 
     // claude-cowork-3p is always global
     const isGlobal = options.global || agent === CLAUDE_COWORK_3P_AGENT || false;

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
-import { getAgentConfig } from '../../core/agent-registry.js';
+import { type AgentType, getAgentConfig, isValidAgentType } from '../../core/agent-registry.js';
+import { CLAUDE_COWORK_3P_AGENT } from '../../core/claude-3p-installer.js';
 import { SkillManager } from '../../core/skill-manager.js';
 import { logger } from '../../utils/logger.js';
 
@@ -11,13 +12,26 @@ export const listCommand = new Command('list')
   .description('List installed skills')
   .option('-j, --json', 'Output as JSON')
   .option('-g, --global', 'List globally installed skills')
+  .option('-a, --agent <agent>', 'List skills installed to a specific agent')
   .action((options) => {
-    const isGlobal = options.global || false;
+    const agent: AgentType | undefined = options.agent;
+
+    if (agent && !isValidAgentType(agent)) {
+      logger.error(`Invalid agent: ${agent}`);
+      process.exit(1);
+    }
+
+    // claude-cowork-3p is always global
+    const isGlobal = options.global || agent === CLAUDE_COWORK_3P_AGENT || false;
     const skillManager = new SkillManager(undefined, { global: isGlobal });
-    const skills = skillManager.list();
+    const skills = skillManager.list(agent ? { agent } : undefined);
 
     if (skills.length === 0) {
-      const location = isGlobal ? 'globally' : 'in this project';
+      const location = agent
+        ? `for ${getAgentConfig(agent).displayName}`
+        : isGlobal
+          ? 'globally'
+          : 'in this project';
       logger.info(`No skills installed ${location}`);
       return;
     }
@@ -27,7 +41,11 @@ export const listCommand = new Command('list')
       return;
     }
 
-    const scopeLabel = isGlobal ? 'global' : 'project';
+    const scopeLabel = agent
+      ? getAgentConfig(agent).displayName
+      : isGlobal
+        ? 'global'
+        : 'project';
     logger.log(`Installed Skills (${scopeLabel}):`);
     logger.newline();
 

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -24,7 +24,7 @@ export const listCommand = new Command('list')
     const agent = agentInput as AgentType | undefined;
 
     // claude-cowork-3p is always global
-    const isGlobal = options.global || agent === CLAUDE_COWORK_3P_AGENT || false;
+    const isGlobal = options.global || agent === CLAUDE_COWORK_3P_AGENT;
     const skillManager = new SkillManager(undefined, { global: isGlobal });
     const skills = skillManager.list(agent ? { agent } : undefined);
 

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -810,6 +810,41 @@ describe('SkillManager bug fixes', () => {
       expect(skills).toHaveLength(1);
       expect(skills[0].name).toBe('shared-skill');
     });
+
+    it('should list skills filtered by agent', () => {
+      // Create skill in cursor agent directory
+      const cursorDir = path.join(tempDir, '.cursor', 'skills', 'cursor-skill');
+      fs.mkdirSync(cursorDir, { recursive: true });
+      fs.writeFileSync(path.join(cursorDir, 'SKILL.md'), '# Cursor Skill');
+
+      // Create skill in claude-code agent directory (should not appear)
+      const claudeDir = path.join(tempDir, '.claude', 'skills', 'claude-skill');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.writeFileSync(path.join(claudeDir, 'SKILL.md'), '# Claude Skill');
+
+      const skills = skillManager.list({ agent: 'cursor' });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].name).toBe('cursor-skill');
+    });
+
+    it('should return empty array when no skills exist for the specified agent', () => {
+      const skills = skillManager.list({ agent: 'codex' });
+      expect(skills).toHaveLength(0);
+    });
+
+    it('should still list all skills when no agent filter is specified', () => {
+      // Create skill in canonical location
+      const canonicalDir = path.join(tempDir, '.agents', 'skills', 'my-skill');
+      fs.mkdirSync(canonicalDir, { recursive: true });
+      fs.writeFileSync(path.join(canonicalDir, 'SKILL.md'), '# My Skill');
+
+      const skillsWithFilter = skillManager.list({ agent: 'cursor' });
+      const skillsWithout = skillManager.list();
+
+      expect(skillsWithFilter).toHaveLength(0); // Not in cursor dir
+      expect(skillsWithout).toHaveLength(1); // In canonical dir
+    });
   });
 
   describe('getInstalledSkill() should find skills in canonical directory', () => {

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -695,9 +695,14 @@ export class SkillManager {
   /**
    * List installed skills
    *
-   * Checks both canonical (.agents/skills/) and legacy (.skills/) locations.
+   * When `agent` is specified, lists skills installed to that specific agent.
+   * Otherwise checks both canonical (.agents/skills/) and legacy (.skills/) locations.
    */
-  list(): InstalledSkill[] {
+  list(options?: { agent?: AgentType }): InstalledSkill[] {
+    if (options?.agent) {
+      return this.listByAgent(options.agent);
+    }
+
     const skills: InstalledSkill[] = [];
     const seenNames = new Set<string>();
 
@@ -749,6 +754,33 @@ export class SkillManager {
           skills.push(skill);
           seenNames.add(name);
         }
+      }
+    }
+
+    return skills;
+  }
+
+  /**
+   * List skills installed to a specific agent
+   */
+  private listByAgent(agent: AgentType): InstalledSkill[] {
+    const installer = new Installer({
+      cwd: this.projectRoot,
+      global: this.isGlobal,
+    });
+
+    const skillNames = installer.listInstalledSkills(agent);
+    const skills: InstalledSkill[] = [];
+
+    for (const name of skillNames) {
+      try {
+        const skillPath = installer.getAgentSkillPath(name, agent);
+        const skill = this.getInstalledSkillFromPath(name, skillPath);
+        if (skill) {
+          skills.push(skill);
+        }
+      } catch {
+        // Skip skills whose paths cannot be resolved (e.g. claude-3p not configured)
       }
     }
 

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -32,7 +32,11 @@ import {
   isValidAgentType,
 } from './agent-registry.js';
 import { CacheManager } from './cache-manager.js';
-import { CLAUDE_COWORK_3P_AGENT, getClaude3pSkillPath } from './claude-3p-installer.js';
+import {
+  CLAUDE_COWORK_3P_AGENT,
+  getClaude3pSkillPath,
+  listClaude3pSkills,
+} from './claude-3p-installer.js';
 import { ConfigLoader, DEFAULT_REGISTRIES } from './config-loader.js';
 import { GitResolver } from './git-resolver.js';
 import { HttpResolver } from './http-resolver.js';
@@ -754,6 +758,25 @@ export class SkillManager {
           skills.push(skill);
           seenNames.add(name);
         }
+      }
+    }
+
+    // In global mode, also include claude-cowork-3p skills (always global)
+    if (this.isGlobal) {
+      try {
+        for (const name of listClaude3pSkills()) {
+          if (seenNames.has(name)) {
+            continue;
+          }
+          const skillPath = getClaude3pSkillPath(name);
+          const skill = this.getInstalledSkillFromPath(name, skillPath);
+          if (skill) {
+            skills.push(skill);
+            seenNames.add(name);
+          }
+        }
+      } catch {
+        // Claude Cowork 3P not configured or accessible — skip silently
       }
     }
 


### PR DESCRIPTION
## Summary

- Add `-a, --agent <agent>` option to `reskill list` command
- `reskill list -a claude-cowork-3p` lists skills installed to Claude Cowork 3P (implicitly global)
- `reskill list -a cursor` lists skills in the cursor agent directory
- Invalid agent names produce a clear error message
- Update README (EN/ZH) to reflect `-a` now applies to both `install` and `list`

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:run` — all 1501 tests pass
- [x] Manual: `reskill list -a cursor` shows skills in `.cursor/skills/`
- [x] Manual: `reskill list -a claude-cowork-3p` returns empty (no local 3P root) without error
- [x] Manual: `reskill list -a invalid-agent` exits with error
- [x] Manual: `reskill list --help` shows new `-a` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)