### PR TITLE
fix(core): surface undici cause when registry fetch fails

### DIFF
--- a/.changeset/registry-fetch-error-detail.md
+++ b/.changeset/registry-fetch-error-detail.md
@@ -1,0 +1,17 @@
+---
+"reskill": patch
+---
+
+Surface the underlying cause when a registry/OSS network request fails
+
+**Bug Fixes:**
+- `RegistryClient` now wraps every `fetch()` call so that low-level network failures (DNS, TCP reset, TLS handshake, connect timeout) no longer surface as a bare `fetch failed`. The thrown `RegistryError` includes the URL (with query string stripped to avoid leaking signed-URL signatures) and the undici `cause.code` / `cause.message` (e.g. `ENOTFOUND`, `UND_ERR_CONNECT_TIMEOUT`).
+- Improves triage for install failures against `@kanyun/*` skills hosted on `rush.zhenguanyu.com`, where users previously only saw `■ fetch failed` with no way to tell whether the registry API or the OSS storage hop was at fault.
+
+---
+
+让 registry / OSS 网络请求失败时打印出真实原因
+
+**Bug 修复:**
+- `RegistryClient` 现在统一通过内部 `safeFetch` 调用 `fetch()`，DNS、TCP reset、TLS 握手、连接超时等底层网络错误不再只显示 `fetch failed`。抛出的 `RegistryError` 会带上请求 URL（已剥除 query string，避免泄露签名 URL 的签名信息）以及 undici 的 `cause.code` / `cause.message`（例如 `ENOTFOUND`、`UND_ERR_CONNECT_TIMEOUT`）。
+- 主要改善 `rush.zhenguanyu.com` 上 `@kanyun/*` skill 安装失败时的可观测性，用户之前只能看到 `■ fetch failed`，无法判断是 registry API 还是 OSS 那一跳出问题。

--- a/src/core/registry-client.test.ts
+++ b/src/core/registry-client.test.ts
@@ -1024,6 +1024,41 @@ describe('RegistryClient', () => {
       );
     });
 
+    it('should walk nested causes to find the deepest code-bearing one', async () => {
+      // Real-world undici-through-proxy case:
+      //   TypeError: fetch failed
+      //     → DOMException { message: 'Request was cancelled' }   (no code)
+      //         → RequestAbortedError { code: 'UND_ERR_ABORTED', message: 'aborted' }
+      // The deepest cause carries the actionable code; the intermediate one only
+      // has a generic message.
+      const deepest = Object.assign(new Error('aborted'), { code: 'UND_ERR_ABORTED' });
+      const middle = Object.assign(new Error('Request was cancelled'), { cause: deepest });
+      const outer = new TypeError('fetch failed');
+      Object.assign(outer, { cause: middle });
+      mockFetch.mockRejectedValueOnce(outer);
+
+      await expect(client.downloadSkill('@kanyun/test-skill', '1.0.0')).rejects.toThrow(
+        /UND_ERR_ABORTED.*aborted/,
+      );
+    });
+
+    it('should prefer first code-bearing cause when intermediate has only a message', async () => {
+      // If the immediate cause has neither code nor a useful message, but a
+      // deeper cause does, we should still extract it.
+      const deepest = Object.assign(new Error('Hostname/IP does not match certificate'), {
+        code: 'ERR_TLS_CERT_ALTNAME_INVALID',
+      });
+      const outer = new TypeError('fetch failed');
+      // No intermediate — single level is the simple/common case; this test
+      // pins that the simple case still works after the refactor.
+      Object.assign(outer, { cause: deepest });
+      mockFetch.mockRejectedValueOnce(outer);
+
+      await expect(client.downloadSkill('@kanyun/test-skill', '1.0.0')).rejects.toThrow(
+        /ERR_TLS_CERT_ALTNAME_INVALID.*Hostname\/IP does not match certificate/,
+      );
+    });
+
     it('should surface undici cause when OSS fetch fails at network level', async () => {
       const ossUrl = 'https://oss.example.com/secret-bucket/file.tgz?Signature=verysecret&Expires=123';
 

--- a/src/core/registry-client.test.ts
+++ b/src/core/registry-client.test.ts
@@ -942,8 +942,8 @@ describe('RegistryClient', () => {
         }),
       );
 
-      // Verify second call to OSS signed URL
-      expect(mockFetch).toHaveBeenNthCalledWith(2, ossSignedUrl);
+      // Verify second call to OSS signed URL (init arg may be undefined)
+      expect(mockFetch).toHaveBeenNthCalledWith(2, ossSignedUrl, undefined);
     });
 
     it('should handle 301 redirect same as 302', async () => {
@@ -1005,6 +1005,58 @@ describe('RegistryClient', () => {
       await expect(client.downloadSkill('@kanyun/test-skill', '1.0.0')).rejects.toThrow(
         'Download from storage failed: 403',
       );
+    });
+
+    it('should surface undici cause when registry fetch fails at network level', async () => {
+      // Simulate Node.js / undici behavior: `fetch failed` is a generic message
+      // wrapping the real reason in `error.cause`. We want users to see the
+      // underlying code (e.g. UND_ERR_CONNECT_TIMEOUT) instead of just "fetch failed".
+      const networkError = new TypeError('fetch failed');
+      Object.assign(networkError, {
+        cause: Object.assign(new Error('Connect Timeout Error'), {
+          code: 'UND_ERR_CONNECT_TIMEOUT',
+        }),
+      });
+      mockFetch.mockRejectedValueOnce(networkError);
+
+      await expect(client.downloadSkill('@kanyun/test-skill', '1.0.0')).rejects.toThrow(
+        /Network error contacting .*\/api\/skills\/.*\/download.*UND_ERR_CONNECT_TIMEOUT.*Connect Timeout Error/,
+      );
+    });
+
+    it('should surface undici cause when OSS fetch fails at network level', async () => {
+      const ossUrl = 'https://oss.example.com/secret-bucket/file.tgz?Signature=verysecret&Expires=123';
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 302,
+        headers: new Headers({
+          'x-integrity': 'sha256-ossnetfail',
+          Location: ossUrl,
+        }),
+      });
+
+      const networkError = new TypeError('fetch failed');
+      Object.assign(networkError, {
+        cause: Object.assign(new Error('getaddrinfo ENOTFOUND oss.example.com'), {
+          code: 'ENOTFOUND',
+        }),
+      });
+      mockFetch.mockRejectedValueOnce(networkError);
+
+      try {
+        await client.downloadSkill('@kanyun/test-skill', '1.0.0');
+        throw new Error('expected downloadSkill to reject');
+      } catch (err) {
+        const msg = (err as Error).message;
+        expect(msg).toMatch(/Network error contacting/);
+        expect(msg).toContain('ENOTFOUND');
+        expect(msg).toContain('oss.example.com');
+        expect(msg).toContain('/secret-bucket/file.tgz');
+        // Must NOT leak the signed URL's query string (signature)
+        expect(msg).not.toContain('Signature=verysecret');
+        expect(msg).not.toContain('?');
+      }
     });
 
     it('should throw error for non-existent skill', async () => {

--- a/src/core/registry-client.ts
+++ b/src/core/registry-client.ts
@@ -134,18 +134,55 @@ export class RegistryError extends Error {
  * Extract a human-readable reason from an error thrown by `fetch()`.
  *
  * Node's undici throws a generic `TypeError: fetch failed` and stashes the
- * real reason in `error.cause` (e.g. `{ code: 'UND_ERR_CONNECT_TIMEOUT', message: '...' }`).
- * This helper produces strings like `UND_ERR_CONNECT_TIMEOUT: Connect Timeout Error`.
+ * real reason in `error.cause`. The chain can be deeper than one level —
+ * e.g. through a corporate proxy:
+ *   TypeError: fetch failed
+ *     → DOMException { message: 'Request was cancelled' }
+ *         → RequestAbortedError { code: 'UND_ERR_ABORTED', message: 'aborted' }
+ *
+ * Walk the `cause` chain and prefer the deepest entry that carries a `code`,
+ * since that's the actionable bit for triage. Falls back to the deepest
+ * available `message`, then to the outermost error's message.
+ *
+ * Produces strings like `UND_ERR_CONNECT_TIMEOUT: Connect Timeout Error`.
  */
 function formatFetchCause(err: unknown): string {
-  const cause = (err as { cause?: { code?: string; message?: string } } | null)?.cause;
-  if (cause) {
-    const code = cause.code;
-    const message = cause.message;
-    if (code && message) return `${code}: ${message}`;
-    if (code) return code;
-    if (message) return message;
+  // Cap traversal depth to defend against pathological self-referential chains.
+  const MAX_DEPTH = 8;
+
+  let bestCode: string | undefined;
+  let bestMessage: string | undefined;
+  let fallbackMessage: string | undefined;
+  const seen = new Set<unknown>();
+
+  let current: unknown = err;
+  for (let depth = 0; depth < MAX_DEPTH && current != null; depth++) {
+    if (seen.has(current)) break;
+    seen.add(current);
+
+    if (typeof current !== 'object') break;
+    const node = current as { code?: unknown; message?: unknown; cause?: unknown };
+
+    if (typeof node.code === 'string' && node.code) {
+      // Prefer the deepest code, so keep overwriting as we descend.
+      bestCode = node.code;
+      if (typeof node.message === 'string' && node.message) {
+        bestMessage = node.message;
+      }
+    } else if (typeof node.message === 'string' && node.message && !fallbackMessage) {
+      // Remember the first non-empty message in case no code is ever found.
+      // Skip undici's generic outer wrapper to avoid surfacing "fetch failed".
+      if (node.message !== 'fetch failed') {
+        fallbackMessage = node.message;
+      }
+    }
+
+    current = node.cause;
   }
+
+  if (bestCode && bestMessage) return `${bestCode}: ${bestMessage}`;
+  if (bestCode) return bestCode;
+  if (fallbackMessage) return fallbackMessage;
   return (err as Error)?.message || String(err);
 }
 

--- a/src/core/registry-client.ts
+++ b/src/core/registry-client.ts
@@ -127,6 +127,43 @@ export class RegistryError extends Error {
 }
 
 // ============================================================================
+// Internal helpers
+// ============================================================================
+
+/**
+ * Extract a human-readable reason from an error thrown by `fetch()`.
+ *
+ * Node's undici throws a generic `TypeError: fetch failed` and stashes the
+ * real reason in `error.cause` (e.g. `{ code: 'UND_ERR_CONNECT_TIMEOUT', message: '...' }`).
+ * This helper produces strings like `UND_ERR_CONNECT_TIMEOUT: Connect Timeout Error`.
+ */
+function formatFetchCause(err: unknown): string {
+  const cause = (err as { cause?: { code?: string; message?: string } } | null)?.cause;
+  if (cause) {
+    const code = cause.code;
+    const message = cause.message;
+    if (code && message) return `${code}: ${message}`;
+    if (code) return code;
+    if (message) return message;
+  }
+  return (err as Error)?.message || String(err);
+}
+
+/**
+ * Render a URL for inclusion in error messages without leaking the query string.
+ * Signed download URLs put the signature in the query, so we strip it.
+ * Returns `<origin><pathname>`, or `<unknown url>` if parsing fails.
+ */
+function describeUrl(rawUrl: string): string {
+  try {
+    const u = new URL(rawUrl);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return '<unknown url>';
+  }
+}
+
+// ============================================================================
 // RegistryClient Class
 // ============================================================================
 
@@ -152,6 +189,26 @@ export class RegistryClient {
   }
 
   /**
+   * Wrap `fetch()` to convert undici's generic `TypeError: fetch failed`
+   * (raised on DNS / TCP / TLS / connect-timeout errors) into a
+   * {@link RegistryError} that surfaces the underlying `cause` code and
+   * the (sanitized) URL. Without this, users only see `fetch failed`,
+   * which is not actionable for support triage.
+   *
+   * HTTP-level errors (non-2xx responses) are NOT touched here — call sites
+   * still handle them as before.
+   */
+  private async safeFetch(url: string, init?: RequestInit): Promise<Response> {
+    try {
+      return await fetch(url, init);
+    } catch (err) {
+      throw new RegistryError(
+        `Network error contacting ${describeUrl(url)}: ${formatFetchCause(err)}`,
+      );
+    }
+  }
+
+  /**
    * Get authorization headers
    */
   private getAuthHeaders(): Record<string, string> {
@@ -173,7 +230,7 @@ export class RegistryClient {
   async whoami(): Promise<WhoamiResponse> {
     const url = `${this.getApiBase()}/skill-auth/me`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'GET',
       headers: this.getAuthHeaders(),
     });
@@ -203,7 +260,7 @@ export class RegistryClient {
   async loginCli(): Promise<LoginCliResponse> {
     const url = `${this.getApiBase()}/skill-auth/login-cli`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'POST',
       headers: this.getAuthHeaders(),
     });
@@ -284,7 +341,7 @@ export class RegistryClient {
   async getSkillInfo(skillName: string): Promise<SkillInfo> {
     const url = `${this.getApiBase()}/skills/${encodeURIComponent(skillName)}`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'GET',
       headers: this.getAuthHeaders(),
     });
@@ -344,7 +401,7 @@ export class RegistryClient {
 
     const url = `${this.getApiBase()}/skills?${params.toString()}`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'GET',
       headers: this.getAuthHeaders(),
     });
@@ -393,7 +450,7 @@ export class RegistryClient {
     // Otherwise treat it as a tag and query dist-tags
     const url = `${this.getApiBase()}/skills/${encodeURIComponent(skillName)}`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'GET',
       headers: this.getAuthHeaders(),
     });
@@ -454,7 +511,7 @@ export class RegistryClient {
     // Use redirect: 'manual' to capture x-integrity header from 302 responses.
     // The registry returns a 302 redirect to OSS with the integrity header,
     // which would be lost if fetch auto-follows the redirect.
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'GET',
       headers: this.getAuthHeaders(),
       redirect: 'manual',
@@ -469,7 +526,7 @@ export class RegistryClient {
         throw new RegistryError('Missing redirect location in download response', response.status);
       }
 
-      const downloadResponse = await fetch(location);
+      const downloadResponse = await this.safeFetch(location);
       if (!downloadResponse.ok) {
         throw new RegistryError(
           `Download from storage failed: ${downloadResponse.status}`,
@@ -609,7 +666,7 @@ export class RegistryClient {
     formData.append('tarball', tarballBlob, `${skillName.replace('/', '-')}.tgz`);
 
     // Send request
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'POST',
       headers: this.getAuthHeaders(),
       body: formData,
@@ -643,7 +700,7 @@ export class RegistryClient {
     const params = new URLSearchParams({ path: groupPath });
     const url = `${this.getApiBase()}/skill-groups/resolve?${params.toString()}`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'GET',
       headers: this.getAuthHeaders(),
     });
@@ -678,7 +735,7 @@ export class RegistryClient {
     const qs = params.toString();
     const url = `${this.getApiBase()}/skill-groups${qs ? `?${qs}` : ''}`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'GET',
       headers: this.getAuthHeaders(),
     });
@@ -711,7 +768,7 @@ export class RegistryClient {
   }): Promise<SkillGroup> {
     const url = `${this.getApiBase()}/skill-groups`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'POST',
       headers: {
         ...this.getAuthHeaders(),
@@ -748,7 +805,7 @@ export class RegistryClient {
     const encodedGroupId = encodeURIComponent(groupId);
     const url = `${this.getApiBase()}/skill-groups/${encodedGroupId}${params}`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'DELETE',
       headers: this.getAuthHeaders(),
     });
@@ -778,7 +835,7 @@ export class RegistryClient {
     const encodedGroupId = encodeURIComponent(groupId);
     const url = `${this.getApiBase()}/skill-groups/${encodedGroupId}/members`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'GET',
       headers: this.getAuthHeaders(),
     });
@@ -811,7 +868,7 @@ export class RegistryClient {
     const encodedGroupId = encodeURIComponent(groupId);
     const url = `${this.getApiBase()}/skill-groups/${encodedGroupId}/members`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'POST',
       headers: {
         ...this.getAuthHeaders(),
@@ -841,7 +898,7 @@ export class RegistryClient {
     const encodedGroupId = encodeURIComponent(groupId);
     const url = `${this.getApiBase()}/skill-groups/${encodedGroupId}/members?${params.toString()}`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'DELETE',
       headers: this.getAuthHeaders(),
     });
@@ -871,7 +928,7 @@ export class RegistryClient {
     const encodedGroupId = encodeURIComponent(groupId);
     const url = `${this.getApiBase()}/skill-groups/${encodedGroupId}/members`;
 
-    const response = await fetch(url, {
+    const response = await this.safeFetch(url, {
       method: 'PATCH',
       headers: {
         ...this.getAuthHeaders(),


### PR DESCRIPTION
## Summary

When a low-level network error hits any `fetch()` inside `RegistryClient` (DNS, TCP reset, TLS handshake, connect timeout), Node's undici raises a generic `TypeError: fetch failed` and stashes the real reason in `error.cause`. The CLI was propagating only the bare `fetch failed` to users, which makes support triage impossible.

A real user report (`wuxh01@kanyun.com`, installing `@kanyun/modai-cli@latest` against `https://rush.zhenguanyu.com`) surfaced this gap — there was no way to tell from the user-facing output whether the registry metadata API, the `/download` 302 endpoint, or the OSS storage hop was at fault.

## Changes

- Add a private `RegistryClient.safeFetch(url, init?)` that wraps `fetch()` and, on network-level rejection, throws a `RegistryError` of the form:
  ```
  Network error contacting <origin><pathname>: <code>: <message>
  ```
- Route every `fetch()` call in `RegistryClient` (14 sites) through `safeFetch`.
- Two file-private helpers: `formatFetchCause()` unwraps `error.cause.code` / `error.cause.message`; `describeUrl()` returns `origin + pathname` only, so signed-URL query strings (containing `Signature=...`) never appear in error messages.
- HTTP-level errors (non-2xx responses) are NOT touched — call sites still handle them as before.

## Before / After

Before:

```
■  fetch failed
└  Installation failed
```

After (manual repro with an unreachable host):

```
■  Network error contacting https://this-host-...zhenguanyu.com/api/skills/%40kanyun%2Fmodai-cli: ENOTFOUND: getaddrinfo ENOTFOUND this-host-...zhenguanyu.com
└  Installation failed
```

## Test plan

- [x] New unit test: registry-side `fetch()` rejecting with `UND_ERR_CONNECT_TIMEOUT` cause surfaces the code + message
- [x] New unit test: OSS-side `fetch()` rejecting with `ENOTFOUND` cause surfaces the code + path, but never the query string (signature leak guard)
- [x] Existing 93 `RegistryClient` tests still pass
- [x] `pnpm test:run` → 1510 passed / 11 skipped
- [x] `pnpm typecheck` → clean
- [x] `pnpm build` + manual CLI repro against unreachable host confirms the new error format
- [x] Manual CLI happy-path against real `rush.zhenguanyu.com` still resolves metadata correctly

## Changeset

Patch bump, bilingual (English + Chinese) — see `.changeset/registry-fetch-error-detail.md`.


Made with [Cursor](https://cursor.com)