### PR TITLE
fix(core): make "already installed" check per-agent instead of global

### DIFF
--- a/.changeset/fix-per-agent-install-check.md
+++ b/.changeset/fix-per-agent-install-check.md
@@ -1,0 +1,13 @@
+---
+"reskill": patch
+---
+
+fix(core): make "already installed" check per-agent instead of global
+
+When a skill was installed for one agent (e.g., cursor), installing the same skill to a different agent (e.g., claude-code) was incorrectly skipped with "already installed". The check now verifies per-agent installation status and only skips agents that actually have the skill.
+
+---
+
+fix(core): 将"已安装"检查改为按 agent 维度判断
+
+当一个 skill 已安装到某个 agent（如 cursor）时，再安装到另一个 agent（如 claude-code）会被错误地跳过并提示"已安装"。现在会逐个检查每个目标 agent 的安装状态，仅跳过确实已安装的 agent。

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -2218,6 +2218,197 @@ describe('SkillManager installToAgentsFromRegistry with source_type', () => {
 });
 
 // ============================================================================
+// Per-agent "already installed" check (Issue #276)
+// ============================================================================
+
+describe('SkillManager per-agent installation check', () => {
+  let tempDir: string;
+  let manager: SkillManager;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reskill-per-agent-install-'));
+    manager = new SkillManager(tempDir);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Helper: set up canonical skill path + lock file so the "already installed" branch is reached
+   */
+  function setupInstalledSkill(skillName: string, version: string) {
+    // Create canonical skill directory (.agents/skills/<name>)
+    const canonicalPath = path.join(tempDir, '.agents', 'skills', skillName);
+    fs.mkdirSync(canonicalPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(canonicalPath, 'SKILL.md'),
+      `---\nname: ${skillName}\nversion: ${version}\n---\n\n# ${skillName}\n`,
+    );
+
+    // Create skills.lock with matching version
+    const lockPath = path.join(tempDir, 'skills.lock');
+    const lockData = {
+      lockfileVersion: 1,
+      skills: {
+        [skillName]: {
+          source: `registry:@kanyun/${skillName}`,
+          version,
+          ref: version,
+          resolved: 'https://registry.example.com/',
+          commit: 'sha256-mock',
+          installedAt: new Date().toISOString(),
+          registry: 'https://registry.example.com/',
+        },
+      },
+    };
+    fs.writeFileSync(lockPath, JSON.stringify(lockData, null, 2));
+
+    return canonicalPath;
+  }
+
+  /**
+   * Helper: mock RegistryClient and RegistryResolver for standard registry flow
+   */
+  async function mockRegistryFlow(skillName: string, version: string) {
+    const { RegistryClient } = await import('./registry-client.js');
+    vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockResolvedValue({
+      name: `@kanyun/${skillName}`,
+      source_type: 'registry',
+    });
+
+    const registryResolver = (manager as unknown as { registryResolver: RegistryResolver })
+      .registryResolver;
+    vi.spyOn(registryResolver, 'resolve').mockResolvedValue({
+      parsed: {
+        scope: '@kanyun',
+        name: skillName,
+        version,
+        fullName: `@kanyun/${skillName}`,
+      },
+      shortName: skillName,
+      version,
+      registryUrl: 'https://registry.example.com/',
+      tarball: Buffer.from('mock tarball'),
+      integrity: 'sha256-mock',
+    });
+
+    return registryResolver;
+  }
+
+  it('should install to new agent when skill is already installed for a different agent', async () => {
+    const skillName = 'cli-skill';
+    const version = '1.0.0';
+
+    // Set up: skill exists in canonical location
+    setupInstalledSkill(skillName, version);
+
+    // Set up: skill is installed for cursor (create cursor agent dir at .cursor/skills/)
+    const cursorSkillPath = path.join(tempDir, '.cursor', 'skills', skillName);
+    fs.mkdirSync(cursorSkillPath, { recursive: true });
+    fs.writeFileSync(path.join(cursorSkillPath, 'SKILL.md'), '# skill');
+
+    // Mock registry
+    await mockRegistryFlow(skillName, version);
+
+    // claude-code should NOT have the skill before install
+    const claudeSkillPath = path.join(tempDir, '.claude', 'skills', skillName);
+    expect(fs.existsSync(claudeSkillPath)).toBe(false);
+
+    // Install to claude-code (which doesn't have it yet)
+    const result = await manager.installToAgents(`@kanyun/${skillName}@${version}`, ['claude-code']);
+
+    // Should succeed — not skipped
+    expect(result.skill.name).toBe(skillName);
+    expect(result.results.get('claude-code')?.success).toBe(true);
+
+    // The skill should now actually exist in claude-code's directory
+    expect(fs.existsSync(claudeSkillPath)).toBe(true);
+  });
+
+  it('should skip installation when all target agents already have the skill', async () => {
+    const skillName = 'cli-skill';
+    const version = '1.0.0';
+
+    // Set up: skill exists in canonical location
+    setupInstalledSkill(skillName, version);
+
+    // Set up: skill is installed for both cursor (.cursor/skills/) and claude-code (.claude/skills/)
+    const cursorSkillPath = path.join(tempDir, '.cursor', 'skills', skillName);
+    fs.mkdirSync(cursorSkillPath, { recursive: true });
+    fs.writeFileSync(path.join(cursorSkillPath, 'SKILL.md'), '# skill');
+
+    const claudeSkillPath = path.join(tempDir, '.claude', 'skills', skillName);
+    fs.mkdirSync(claudeSkillPath, { recursive: true });
+    fs.writeFileSync(path.join(claudeSkillPath, 'SKILL.md'), '# skill');
+
+    // Mock registry
+    await mockRegistryFlow(skillName, version);
+
+    // Install to both agents (which already have it)
+    const result = await manager.installToAgents(`@kanyun/${skillName}@${version}`, [
+      'cursor',
+      'claude-code',
+    ]);
+
+    // Should report success without re-downloading
+    expect(result.skill.name).toBe(skillName);
+    expect(result.results.get('cursor')?.success).toBe(true);
+    expect(result.results.get('claude-code')?.success).toBe(true);
+  });
+
+  it('should warn when installed version differs and no --force', async () => {
+    const skillName = 'cli-skill';
+
+    // Set up: skill exists in canonical location with version 1.0.0
+    setupInstalledSkill(skillName, '1.0.0');
+
+    // Mock registry resolves to version 2.0.0 (different from lock)
+    await mockRegistryFlow(skillName, '2.0.0');
+
+    // Install without --force
+    const result = await manager.installToAgents(`@kanyun/${skillName}@2.0.0`, ['cursor']);
+
+    // Should return existing skill info (not re-download), with the existing version
+    expect(result.skill.name).toBe(skillName);
+    // The result returns the already-installed skill, not the new version
+    expect(result.skill.version).toBe('1.0.0');
+  });
+
+  it('should reinstall to all agents when --force is used regardless of installation status', async () => {
+    const skillName = 'cli-skill';
+    const version = '1.0.0';
+
+    // Set up: skill exists in canonical location
+    setupInstalledSkill(skillName, version);
+
+    // Set up: skill is installed for cursor (.cursor/skills/)
+    const cursorSkillPath = path.join(tempDir, '.cursor', 'skills', skillName);
+    fs.mkdirSync(cursorSkillPath, { recursive: true });
+    fs.writeFileSync(path.join(cursorSkillPath, 'SKILL.md'), '# skill');
+
+    // Mock registry
+    const registryResolver = await mockRegistryFlow(skillName, version);
+
+    // Mock extract to return a valid path
+    const mockSkillDir = path.join(tempDir, 'mock-extracted-skill');
+    fs.mkdirSync(mockSkillDir, { recursive: true });
+    fs.writeFileSync(path.join(mockSkillDir, 'SKILL.md'), `---\nname: ${skillName}\nversion: ${version}\n---\n# skill`);
+    vi.spyOn(registryResolver, 'extract').mockResolvedValue(mockSkillDir);
+
+    // Install with --force to cursor (which already has it)
+    const result = await manager.installToAgents(`@kanyun/${skillName}@${version}`, ['cursor'], {
+      force: true,
+    });
+
+    // Should reinstall (force bypasses the check entirely)
+    expect(result.skill.name).toBe(skillName);
+    expect(result.results.get('cursor')?.success).toBe(true);
+  });
+});
+
+// ============================================================================
 // Tests for SKILL.md as authoritative source for skill name
 // ============================================================================
 

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -2323,8 +2323,11 @@ describe('SkillManager per-agent installation check', () => {
     expect(result.skill.name).toBe(skillName);
     expect(result.results.get('claude-code')?.success).toBe(true);
 
-    // The skill should now actually exist in claude-code's directory
+    // The skill should now actually exist in claude-code's directory with valid content
     expect(fs.existsSync(claudeSkillPath)).toBe(true);
+    expect(fs.existsSync(path.join(claudeSkillPath, 'SKILL.md'))).toBe(true);
+    const content = fs.readFileSync(path.join(claudeSkillPath, 'SKILL.md'), 'utf-8');
+    expect(content).toContain('cli-skill');
   });
 
   it('should skip installation when all target agents already have the skill', async () => {

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1525,9 +1525,11 @@ export class SkillManager {
           );
         }
 
-        // Install to missing agents from the existing skillPath (no need to re-download)
+        // Install to missing agents from the existing skillPath (no need to re-download).
+        // Use 'copy' mode here because skillPath IS the canonical directory — symlink mode
+        // would remove(canonicalDir) before copyDirectory, destroying the source.
         const results = await installer.installToAgents(skillPath, shortName, missingAgents, {
-          mode: mode as InstallMode,
+          mode: 'copy',
         });
 
         // Add already-installed agents to results

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1488,21 +1488,65 @@ export class SkillManager {
       const locked = this.lockManager.get(shortName);
       const lockedVersion = locked?.version;
 
-      // Same version already installed
       if (locked && lockedVersion === version) {
-        logger.info(`${shortName}@${version} is already installed.`);
-        const installed = this.getInstalledSkill(shortName);
-        if (installed) {
-          return {
-            skill: installed,
-            results: new Map(
-              targetAgents.map((a) => [
-                a,
-                { success: true, path: skillPath, mode: mode as InstallMode },
-              ]),
-            ),
-          };
+        // Same version in canonical location — check per-agent
+        const defaults = this.config.getDefaults();
+        const installer = new Installer({
+          cwd: this.projectRoot,
+          global: this.isGlobal,
+          installDir: defaults.installDir,
+        });
+
+        const missingAgents = targetAgents.filter(
+          (agent) => !installer.isInstalled(shortName, agent),
+        );
+
+        if (missingAgents.length === 0) {
+          // All target agents already have it
+          logger.info(`${shortName}@${version} is already installed.`);
+          const installed = this.getInstalledSkill(shortName);
+          if (installed) {
+            return {
+              skill: installed,
+              results: new Map(
+                targetAgents.map((a) => [
+                  a,
+                  { success: true, path: skillPath, mode: mode as InstallMode },
+                ]),
+              ),
+            };
+          }
         }
+
+        // Some agents missing — install to those agents from existing canonical path
+        if (missingAgents.length < targetAgents.length) {
+          logger.info(
+            `${shortName}@${version} already installed for ${targetAgents.length - missingAgents.length} agent(s), installing to ${missingAgents.length} more...`,
+          );
+        }
+
+        // Install to missing agents from the existing skillPath (no need to re-download)
+        const results = await installer.installToAgents(skillPath, shortName, missingAgents, {
+          mode: mode as InstallMode,
+        });
+
+        // Add already-installed agents to results
+        for (const agent of targetAgents) {
+          if (!missingAgents.includes(agent)) {
+            results.set(agent, { success: true, path: skillPath, mode: mode as InstallMode });
+          }
+        }
+
+        const successCount = Array.from(results.values()).filter((r) => r.success).length;
+        logger.success(`Installed ${shortName}@${version} to ${successCount} agent(s)`);
+
+        const skill: InstalledSkill = this.getInstalledSkill(shortName) ?? {
+          name: shortName,
+          path: skillPath,
+          version,
+          source: `registry:${resolvedParsed.fullName}`,
+        };
+        return { skill, results };
       }
 
       // Different version or no lock info - warn user


### PR DESCRIPTION
## Summary

- Fix #276: When a skill was installed for one agent (e.g., cursor), installing the same skill to a different agent (e.g., claude-code) was incorrectly skipped with "already installed"
- The check now uses `Installer.isInstalled()` per target agent, only skipping agents that actually have the skill
- If some agents already have it and others don't, only installs to the missing agents without re-downloading

## Test plan

- [x] Added test: install to new agent when skill already installed for different agent (verifies file actually created)
- [x] Added test: skip when all target agents already have the skill
- [x] Added test: warn when version differs and no `--force`
- [x] Added test: `--force` bypasses all checks
- [x] Verified test correctly fails with original bug code (reverted temporarily to confirm)
- [x] `pnpm test:run` — 1516 passed
- [x] `pnpm typecheck` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)