### PR TITLE
fix(core): install to missing agent when canonical exists without lock

### DIFF
--- a/.changeset/fix-3p-install-when-canonical-exists.md
+++ b/.changeset/fix-3p-install-when-canonical-exists.md
@@ -1,0 +1,17 @@
+---
+"reskill": patch
+---
+
+Fix `install` silently skipping the target agent when the canonical skill directory already exists but the lock file is missing or holds a different version.
+
+**Bug Fixes:**
+- `installToAgentsFromRegistry` no longer returns a fake success when the canonical `~/.agents/skills/<name>` directory exists but the target agent (e.g. `claude-cowork-3p`) is still missing the skill. The CLI now reuses the cached canonical copy to install into the missing agent's directory and reports the agent-specific install path instead of the canonical one. Most user-visible scenario: `reskill install @scope/foo@latest -a claude-cowork-3p` after a previous global install would warn "already installed" and never touch the Claude Cowork 3P skills root.
+- The "already installed. Use --force to reinstall." warning now only fires when every target agent already has the skill, matching user expectations.
+
+---
+
+修复 `install` 命令在画布技能目录（canonical）已存在但 lock 文件缺失或版本不一致时，会跳过目标 agent 的安装并伪造成功的问题。
+
+**Bug Fixes:**
+- `installToAgentsFromRegistry` 不再在 `~/.agents/skills/<name>` 已存在、但目标 agent（如 `claude-cowork-3p`）仍未安装该 skill 时返回假成功。CLI 会复用 canonical 缓存目录，把 skill 实际拷贝到缺失的 agent 目录下，并在结果中报告该 agent 自己的安装路径，而不是 canonical 路径。最常见的触发场景：之前做过全局安装后，再执行 `reskill install @scope/foo@latest -a claude-cowork-3p` 时，旧版本会提示 "already installed" 并完全跳过对 Claude Cowork 3P skills 根目录的写入。
+- "already installed. Use --force to reinstall." 警告现在仅在所有目标 agent 都已安装该 skill 时才会出现，与用户预期一致。

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -2409,6 +2409,99 @@ describe('SkillManager per-agent installation check', () => {
     expect(result.skill.name).toBe(skillName);
     expect(result.results.get('cursor')?.success).toBe(true);
   });
+
+  // ----------------------------------------------------------------------
+  // Bug repro: canonical skill exists without lock file (e.g. previous
+  // global install), now installing for a new agent should still copy the
+  // skill into that agent's directory instead of returning a fake success.
+  // ----------------------------------------------------------------------
+
+  /**
+   * Helper: create canonical skill WITHOUT writing a lock file.
+   * Simulates the state after a previous global install (no lock written).
+   */
+  function setupCanonicalSkillNoLock(skillName: string, version: string): string {
+    const canonicalPath = path.join(tempDir, '.agents', 'skills', skillName);
+    fs.mkdirSync(canonicalPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(canonicalPath, 'SKILL.md'),
+      `---\nname: ${skillName}\nversion: ${version}\n---\n\n# ${skillName}\n`,
+    );
+    return canonicalPath;
+  }
+
+  it('should install to target agent when canonical exists but no lock file (fixes regression)', async () => {
+    const skillName = 'cli-skill';
+    const version = '1.0.0';
+
+    // Canonical exists from a previous (global) install — no lock file written.
+    setupCanonicalSkillNoLock(skillName, version);
+
+    // Target agent (cursor) does NOT have the skill installed.
+    const cursorSkillPath = path.join(tempDir, '.cursor', 'skills', skillName);
+    expect(fs.existsSync(cursorSkillPath)).toBe(false);
+
+    await mockRegistryFlow(skillName, version);
+
+    const result = await manager.installToAgents(`@kanyun/${skillName}@${version}`, ['cursor']);
+
+    // Cursor must actually receive the skill (this was the bug — it didn't).
+    expect(result.results.get('cursor')?.success).toBe(true);
+    expect(fs.existsSync(cursorSkillPath)).toBe(true);
+    expect(fs.existsSync(path.join(cursorSkillPath, 'SKILL.md'))).toBe(true);
+  });
+
+  it('should install to claude-cowork-3p when canonical exists but skill not in claude-3p root (fixes user-reported bug)', async () => {
+    const { CLAUDE_3P_SKILLS_ROOT_ENV } = await import('./claude-3p-installer.js');
+    const skillName = 'docz';
+    const version = '0.10.0';
+
+    // Set up an isolated claude-3p skills root for this test.
+    const claude3pRoot = path.join(tempDir, 'claude-3p-root');
+    fs.mkdirSync(path.join(claude3pRoot, 'skills'), { recursive: true });
+    fs.writeFileSync(path.join(claude3pRoot, 'manifest.json'), '{"skills":[]}\n');
+    const originalRoot = process.env[CLAUDE_3P_SKILLS_ROOT_ENV];
+    process.env[CLAUDE_3P_SKILLS_ROOT_ENV] = claude3pRoot;
+
+    try {
+      // Canonical exists from a previous install (no lock — global install scenario).
+      setupCanonicalSkillNoLock(skillName, version);
+
+      // claude-3p does NOT have the skill yet.
+      const claude3pSkillPath = path.join(claude3pRoot, 'skills', skillName);
+      expect(fs.existsSync(claude3pSkillPath)).toBe(false);
+
+      await mockRegistryFlow(skillName, version);
+
+      const result = await manager.installToAgents(`@kanyun/${skillName}@${version}`, [
+        'claude-cowork-3p',
+      ]);
+
+      // The skill must actually land in the claude-3p skills root.
+      expect(result.results.get('claude-cowork-3p')?.success).toBe(true);
+      expect(fs.existsSync(claude3pSkillPath)).toBe(true);
+      expect(fs.existsSync(path.join(claude3pSkillPath, 'SKILL.md'))).toBe(true);
+
+      // The returned path should point at the claude-3p location, not the
+      // canonical directory (this is what makes the CLI output truthful).
+      const installResult = result.results.get('claude-cowork-3p');
+      expect(installResult?.path).toBe(claude3pSkillPath);
+
+      // The manifest.json should record the new skill.
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(claude3pRoot, 'manifest.json'), 'utf-8'),
+      );
+      expect(manifest.skills).toEqual(
+        expect.arrayContaining([expect.objectContaining({ skillId: skillName })]),
+      );
+    } finally {
+      if (originalRoot === undefined) {
+        delete process.env[CLAUDE_3P_SKILLS_ROOT_ENV];
+      } else {
+        process.env[CLAUDE_3P_SKILLS_ROOT_ENV] = originalRoot;
+      }
+    }
+  });
 });
 
 // ============================================================================

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1483,88 +1483,94 @@ export class SkillManager {
     } = resolved;
 
     // 2. Check if already installed (skip if --force)
+    //
+    // Per-agent installation is the source of truth: even when the canonical
+    // skill directory exists, a specific target agent (e.g. claude-cowork-3p,
+    // which lives outside the canonical tree) may still be missing the skill.
+    // We always check per-agent and only short-circuit when every target
+    // agent already has the skill installed.
     const skillPath = this.getSkillPath(shortName);
     if (exists(skillPath) && !force) {
       const locked = this.lockManager.get(shortName);
       const lockedVersion = locked?.version;
+      const versionMatches = !!locked && lockedVersion === version;
 
-      if (locked && lockedVersion === version) {
-        // Same version in canonical location — check per-agent
-        const defaults = this.config.getDefaults();
-        const installer = new Installer({
-          cwd: this.projectRoot,
-          global: this.isGlobal,
-          installDir: defaults.installDir,
-        });
+      const defaults = this.config.getDefaults();
+      const installer = new Installer({
+        cwd: this.projectRoot,
+        global: this.isGlobal,
+        installDir: defaults.installDir,
+      });
 
-        const missingAgents = targetAgents.filter(
-          (agent) => !installer.isInstalled(shortName, agent),
-        );
+      const missingAgents = targetAgents.filter(
+        (agent) => !installer.isInstalled(shortName, agent),
+      );
 
-        if (missingAgents.length === 0) {
-          // All target agents already have it
+      if (missingAgents.length === 0) {
+        // All target agents already have the skill — true no-op.
+        if (versionMatches) {
           logger.info(`${shortName}@${version} is already installed.`);
-          const installed = this.getInstalledSkill(shortName);
-          if (installed) {
-            return {
-              skill: installed,
-              results: new Map(
-                targetAgents.map((a) => [
-                  a,
-                  { success: true, path: skillPath, mode: mode as InstallMode },
-                ]),
-              ),
-            };
-          }
+        } else {
+          logger.warn(`${shortName} is already installed. Use --force to reinstall.`);
         }
-
-        // Some agents missing — install to those agents from existing canonical path
-        if (missingAgents.length < targetAgents.length) {
-          logger.info(
-            `${shortName}@${version} already installed for ${targetAgents.length - missingAgents.length} agent(s), installing to ${missingAgents.length} more...`,
-          );
+        const installed = this.getInstalledSkill(shortName);
+        if (installed) {
+          return {
+            skill: installed,
+            results: new Map(
+              targetAgents.map((a) => [
+                a,
+                { success: true, path: skillPath, mode: mode as InstallMode },
+              ]),
+            ),
+          };
         }
-
-        // Install to missing agents from the existing skillPath (no need to re-download).
-        // Use 'copy' mode here because skillPath IS the canonical directory — symlink mode
-        // would remove(canonicalDir) before copyDirectory, destroying the source.
-        const results = await installer.installToAgents(skillPath, shortName, missingAgents, {
-          mode: 'copy',
-        });
-
-        // Add already-installed agents to results
-        for (const agent of targetAgents) {
-          if (!missingAgents.includes(agent)) {
-            results.set(agent, { success: true, path: skillPath, mode: mode as InstallMode });
-          }
-        }
-
-        const successCount = Array.from(results.values()).filter((r) => r.success).length;
-        logger.success(`Installed ${shortName}@${version} to ${successCount} agent(s)`);
-
-        const skill: InstalledSkill = this.getInstalledSkill(shortName) ?? {
-          name: shortName,
-          path: skillPath,
-          version,
-          source: `registry:${resolvedParsed.fullName}`,
-        };
-        return { skill, results };
       }
 
-      // Different version or no lock info - warn user
-      logger.warn(`${shortName} is already installed. Use --force to reinstall.`);
-      const installed = this.getInstalledSkill(shortName);
-      if (installed) {
-        return {
-          skill: installed,
-          results: new Map(
-            targetAgents.map((a) => [
-              a,
-              { success: true, path: skillPath, mode: mode as InstallMode },
-            ]),
-          ),
-        };
+      // Some target agents are missing the skill. Reuse the existing canonical
+      // copy instead of re-downloading. This covers two scenarios:
+      //   (a) Same locked version, additional agent requested (Issue #276).
+      //   (b) Canonical exists without lock / with mismatched version (e.g.
+      //       previous global install) and a new agent is requested. Without
+      //       this branch the CLI silently fakes success and never installs
+      //       to the target agent.
+      if (versionMatches) {
+        logger.info(
+          `${shortName}@${version} already installed for ${targetAgents.length - missingAgents.length} agent(s), installing to ${missingAgents.length} more...`,
+        );
+      } else {
+        const installedDesc = lockedVersion ? `${shortName}@${lockedVersion}` : shortName;
+        logger.info(
+          `${installedDesc} already cached, installing to ${missingAgents.length} agent(s). Use --force to fetch ${version}.`,
+        );
       }
+
+      // Use 'copy' mode here because skillPath IS the canonical directory —
+      // symlink mode would remove(canonicalDir) before copyDirectory,
+      // destroying the source.
+      const results = await installer.installToAgents(skillPath, shortName, missingAgents, {
+        mode: 'copy',
+      });
+
+      // Mark already-installed agents as successful so the caller sees the
+      // full set of targets in the result map.
+      for (const agent of targetAgents) {
+        if (!missingAgents.includes(agent)) {
+          results.set(agent, { success: true, path: skillPath, mode: mode as InstallMode });
+        }
+      }
+
+      const successCount = Array.from(results.values()).filter((r) => r.success).length;
+      const displayVersion = lockedVersion ?? version;
+      logger.success(`Installed ${shortName}@${displayVersion} to ${successCount} agent(s)`);
+
+      const skill: InstalledSkill = this.getInstalledSkill(shortName) ?? {
+        name: shortName,
+        path: skillPath,
+        version: displayVersion,
+        source: `registry:${resolvedParsed.fullName}`,
+      };
+      return { skill, results };
     }
 
     logger.package(


### PR DESCRIPTION
## Summary

Fix `installToAgentsFromRegistry` silently skipping the target agent when the canonical skill directory already exists but the lock file is missing or holds a different version.

**User-visible scenario** (reported by liumulin):

```
npx reskill@latest install @kanyun/docz@latest -a claude-cowork-3p -y \
  --registry https://rush.zhenguanyu.com
# ⚠️ docz is already installed. Use --force to reinstall.
# ✓ docz@0.10.0 (copied)
#   → ~/.agents/skills/docz   ← misleading: claude-3p never actually got the skill
```

After a previous (global) install left `~/.agents/skills/docz` behind without a matching lock entry, installing for a new agent (e.g. `claude-cowork-3p`) would warn "already installed", fake a success result, and never write to the agent's actual skill directory. The UI then reported the canonical path, making it look like the install succeeded.

## Root cause

`installToAgentsFromRegistry` had a per-agent installation check (Issue #276) for the "lock matches" branch, but the fallback path (`locked` missing or version mismatch) returned a fake success without checking whether each target agent actually had the skill.

## Fix

Per-agent installation is now the single source of truth regardless of lock state:
- All target agents already have it → true no-op (warning only when versions differ).
- Some target agents are missing → reuse the canonical cache (`copy` mode) to install into the missing agent directory, including `claude-cowork-3p` which writes to its own skills root and updates `manifest.json`.
- `--force` continues to bypass the cache and re-fetch from registry.

## Test plan

- [x] Unit tests (RED → GREEN): added 2 tests in \`SkillManager per-agent installation check\` covering the generic-agent and \`claude-cowork-3p\` regressions. Both fail before the fix with the exact \"already installed\" warning from the user's screenshot.
- [x] \`pnpm test:run\` (1518 unit tests passing)
- [x] \`pnpm test:integration\` (253 integration tests passing)
- [x] \`pnpm typecheck\` clean
- [x] Manual end-to-end against the real \`@kanyun\` registry with an isolated \`CLAUDE_3P_SKILLS_ROOT\`:
  - Bug scenario: canonical exists + 3p empty → installs to claude-3p, manifest updated, CLI output points at claude-3p path (not canonical).
  - All target agents already have it → \"already installed. Use --force to reinstall.\" warning, true no-op.
  - \`--force\` → re-fetches \`docz@0.11.0\` from registry and rewrites the 3p skill directory.
- [x] Bilingual (EN + 中文) changeset under \`.changeset/\`.


Made with [Cursor](https://cursor.com)