### PR TITLE
fix(core): support Windows path separators in registry extraction

### DIFF
--- a/.changeset/fix-windows-registry-extraction.md
+++ b/.changeset/fix-windows-registry-extraction.md
@@ -1,0 +1,21 @@
+---
+"reskill": patch
+---
+
+Fix Windows registry tarball extraction and Claude 3P default path
+
+**Bug Fixes:**
+- Fix tarball extraction silently failing on Windows. `isPathSafe()` in the tarball extractor compared resolved paths with a hardcoded `/` separator, which never matches Windows `\` paths, so every entry was rejected and skills extracted into an empty directory (causing `ENOENT ... scandir` during install). The containment check now uses `path.relative`, making it separator-agnostic.
+- Fix the default Claude Cowork 3P (`claude-cowork-3p`) skills base path on Windows. It now resolves to `%LOCALAPPDATA%` (Local) instead of `%APPDATA%` (Roaming), matching where Claude Desktop 3P actually stores its data. Falls back to `<home>/AppData/Local` when `LOCALAPPDATA` is unset.
+
+macOS and Linux behavior is unchanged.
+
+---
+
+修复 Windows 下注册表 tarball 解压以及 Claude 3P 默认路径问题
+
+**Bug 修复:**
+- 修复 Windows 下 tarball 解压静默失败的问题。解压器中的 `isPathSafe()` 使用硬编码的 `/` 分隔符比较解析后的路径，在 Windows 的 `\` 路径下永远不匹配，导致所有条目被拒绝、skill 解压到空目录（安装时报 `ENOENT ... scandir`）。现改用 `path.relative` 做包含性校验，与分隔符无关。
+- 修复 Windows 下 Claude Cowork 3P（`claude-cowork-3p`）默认 skills 路径。现在解析到 `%LOCALAPPDATA%`（Local）而非 `%APPDATA%`（Roaming），与 Claude Desktop 3P 实际存储位置一致；当 `LOCALAPPDATA` 未设置时回退到 `<home>/AppData/Local`。
+
+macOS 与 Linux 行为保持不变。

--- a/src/core/claude-3p-installer.test.ts
+++ b/src/core/claude-3p-installer.test.ts
@@ -90,15 +90,38 @@ description: Test skill for Claude Cowork 3P
       ),
     );
 
+    // Windows: Claude Desktop 3P stores data under %LOCALAPPDATA% (Local),
+    // not %APPDATA% (Roaming).
     expect(
       getClaude3pSkillsPluginBase({
         platform: 'win32',
         homeDir: 'C:\\Users\\Alice',
-        env: { APPDATA: 'C:\\Users\\Alice\\AppData\\Roaming' },
+        env: {
+          LOCALAPPDATA: 'C:\\Users\\Alice\\AppData\\Local',
+          APPDATA: 'C:\\Users\\Alice\\AppData\\Roaming',
+        },
       }),
     ).toBe(
       path.join(
-        'C:\\Users\\Alice\\AppData\\Roaming',
+        'C:\\Users\\Alice\\AppData\\Local',
+        'Claude-3p',
+        'local-agent-mode-sessions',
+        'skills-plugin',
+      ),
+    );
+
+    // Windows fallback: when LOCALAPPDATA is unset, derive Local from homeDir.
+    expect(
+      getClaude3pSkillsPluginBase({
+        platform: 'win32',
+        homeDir: 'C:\\Users\\Alice',
+        env: {},
+      }),
+    ).toBe(
+      path.join(
+        'C:\\Users\\Alice',
+        'AppData',
+        'Local',
         'Claude-3p',
         'local-agent-mode-sessions',
         'skills-plugin',

--- a/src/core/claude-3p-installer.ts
+++ b/src/core/claude-3p-installer.ts
@@ -132,8 +132,10 @@ export function getClaude3pSkillsPluginBase(options: ResolvePathOptions = {}): s
   }
 
   if (currentPlatform === 'win32') {
+    // Claude Desktop 3P stores data under %LOCALAPPDATA% (Local), not
+    // %APPDATA% (Roaming). Fall back to <home>/AppData/Local when unset.
     return path.join(
-      env.APPDATA ?? path.join(homeDir, 'AppData', 'Roaming'),
+      env.LOCALAPPDATA ?? path.join(homeDir, 'AppData', 'Local'),
       'Claude-3p',
       'local-agent-mode-sessions',
       'skills-plugin',

--- a/src/core/extractor.ts
+++ b/src/core/extractor.ts
@@ -52,7 +52,11 @@ export function isPathSafe(installDir: string, entryName: string): boolean {
   // Reject any path containing ".." component
   // Legitimate tarballs never need ".." - all files should be under skill-name/
   // This prevents both system-level escape (../../../etc) and skill-level escape (skill/../other)
-  const parts = entryName.split('/');
+  // Split on the platform separators: on Windows both '\' and '/' are separators,
+  // so a '..' hidden behind a backslash (skill\..\other) must also be caught. On
+  // POSIX, '\' is a valid filename character and must not be treated as a separator.
+  const separatorPattern = sep === '\\' ? /[\\/]/ : /\//;
+  const parts = entryName.split(separatorPattern);
   for (const part of parts) {
     if (part === '..') {
       return false;

--- a/src/core/extractor.ts
+++ b/src/core/extractor.ts
@@ -6,7 +6,7 @@
  */
 
 import { createWriteStream, existsSync, mkdirSync } from 'node:fs';
-import { dirname, isAbsolute, join, normalize, resolve } from 'node:path';
+import { dirname, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
 import { createGunzip } from 'node:zlib';
 import { extract, type Headers } from 'tar-stream';
 
@@ -59,12 +59,19 @@ export function isPathSafe(installDir: string, entryName: string): boolean {
     }
   }
 
-  // Final verification: resolved path must be within installDir
+  // Final verification: resolved path must be within installDir.
+  // Use path.relative so the check is separator-agnostic (works on Windows '\'
+  // and POSIX '/'); a hardcoded '/' rejected every entry on Windows.
   const resolvedInstallDir = resolve(installDir);
   const resolvedEntryPath = resolve(join(installDir, normalizedName));
+  const relativePath = relative(resolvedInstallDir, resolvedEntryPath);
 
-  // Entry must be within install directory (not equal to it, must be a subdirectory)
-  if (!resolvedEntryPath.startsWith(resolvedInstallDir + '/')) {
+  // Entry must be a strict subpath of installDir: non-empty, not escaping via
+  // "..", and not an absolute path.
+  if (!relativePath || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
+    return false;
+  }
+  if (isAbsolute(relativePath)) {
     return false;
   }
 

--- a/src/core/extractor.windows.test.ts
+++ b/src/core/extractor.windows.test.ts
@@ -38,6 +38,14 @@ describe('extractor (Windows path semantics)', () => {
       expect(isPathSafe(installDir, 'skill/../../etc/passwd')).toBe(false);
     });
 
+    it('blocks backslash-separated ".." components (Windows skill-level escape)', () => {
+      // On Windows '\' is a real separator, so these traverse directories and
+      // must be rejected even though split('/') alone would miss them.
+      expect(isPathSafe(installDir, 'skill\\..\\other-skill\\SKILL.md')).toBe(false);
+      expect(isPathSafe(installDir, 'skill\\..\\other-skill/SKILL.md')).toBe(false);
+      expect(isPathSafe(installDir, 'skill\\..\\..\\evil.txt')).toBe(false);
+    });
+
     it('still blocks absolute paths', () => {
       expect(isPathSafe(installDir, 'C:\\Windows\\System32\\evil.dll')).toBe(false);
     });

--- a/src/core/extractor.windows.test.ts
+++ b/src/core/extractor.windows.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Windows-specific Tarball Extractor Tests
+ *
+ * These tests simulate Windows path semantics by mocking `node:path` with its
+ * `win32` implementation. The extractor runs on contributors' macOS/Linux
+ * machines and on CI, so the Windows-only path-safety bug would otherwise never
+ * be exercised.
+ *
+ * Bug: isPathSafe() compared resolved paths using a hardcoded '/' separator,
+ * which never matches Windows '\' separators, causing every tarball entry to be
+ * rejected and skills to extract into an empty directory.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:path', async () => {
+  const actual = await vi.importActual<typeof import('node:path')>('node:path');
+  return { ...actual.win32, default: actual.win32 };
+});
+
+const { isPathSafe } = await import('./extractor.js');
+
+describe('extractor (Windows path semantics)', () => {
+  const installDir = 'C:\\Users\\alice\\.reskill-cache\\registry-temp\\skill-foo-1.0.0';
+
+  describe('isPathSafe with backslash separators', () => {
+    it('allows a normal skill entry under installDir', () => {
+      expect(isPathSafe(installDir, 'skill-foo/SKILL.md')).toBe(true);
+    });
+
+    it('allows nested skill entries', () => {
+      expect(isPathSafe(installDir, 'skill-foo/scripts/init.sh')).toBe(true);
+      expect(isPathSafe(installDir, 'skill-foo/a/b/c/deep.txt')).toBe(true);
+    });
+
+    it('still blocks parent-directory escape', () => {
+      expect(isPathSafe(installDir, '../etc/passwd')).toBe(false);
+      expect(isPathSafe(installDir, 'skill/../../etc/passwd')).toBe(false);
+    });
+
+    it('still blocks absolute paths', () => {
+      expect(isPathSafe(installDir, 'C:\\Windows\\System32\\evil.dll')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a Windows-only bug reported by the DocZ Desktop team where `reskill install ... --registry <url>` downloads the tarball but extracts nothing, then fails with `ENOENT ... scandir` during install.

- **Bug 1 (blocking):** The tarball extractor's `isPathSafe()` compared resolved paths with a hardcoded `/` separator, which never matches Windows `\` paths. Every entry was silently rejected → empty extract dir → `ENOENT` downstream. Replaced with a separator-agnostic `path.relative` containment check.
- **Related:** `getClaude3pSkillsPluginBase()` on Windows defaulted to `%APPDATA%` (Roaming); Claude Desktop 3P actually stores data under `%LOCALAPPDATA%` (Local). Now defaults to `%LOCALAPPDATA%` with a `<home>/AppData/Local` fallback.

macOS/Linux behavior is unchanged.

## Changes

- `src/core/extractor.ts` — use `path.relative` (+ `sep`) for the path-safety containment check
- `src/core/claude-3p-installer.ts` — Windows base path uses `%LOCALAPPDATA%`
- `src/core/extractor.windows.test.ts` — new test mocking `node:path` as `win32` to exercise the Windows-only path (RED before fix)
- `src/core/claude-3p-installer.test.ts` — assert `%LOCALAPPDATA%` + fallback case
- `.changeset/` — bilingual patch changeset

## Test plan

- [x] `pnpm test:run` — 1522 passed / 11 skipped
- [x] `pnpm test:integration` — 253 passed / 9 skipped
- [x] `pnpm typecheck`
- [x] Biome lint clean on changed files
- [x] TDD: new tests fail before the fix (RED), pass after (GREEN)

Made with [Cursor](https://cursor.com)