### PR TITLE
feat(outdated): support registry sources, global mode, and prerelease channel isolation

### DIFF
--- a/.changeset/fix-outdated-registry-global.md
+++ b/.changeset/fix-outdated-registry-global.md
@@ -1,0 +1,19 @@
+---
+"reskill": minor
+---
+
+feat(outdated): support registry source detection and global skill checking
+
+- Fix `reskill outdated` not detecting registry-sourced skills (previously only handled Git sources)
+- Add `-g, --global` flag to check globally installed skills (`~/.agents/skills/`)
+- Add prerelease channel-aware version comparison: stable users only see stable updates, beta users only see beta updates — no cross-channel noise
+- For unscoped global skills, probe known registries to find the source package
+
+---
+
+feat(outdated): 支持 registry 来源检测和全局 skill 检查
+
+- 修复 `reskill outdated` 无法检测 registry 来源的 skill（之前只处理 Git 来源）
+- 新增 `-g, --global` 参数，支持检查全局安装的 skill（`~/.agents/skills/`）
+- 新增预发布版本通道感知：正式版用户只看到正式版更新，beta 用户只看到 beta 更新，不会跨通道提示
+- 对无 scope 的全局 skill，自动探测已知 registry 查找源包

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npx reskill@latest <command>  # Or use npx directly
 | Option                    | Commands                                                      | Description                                                   |
 | ------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------- |
 | `--no-save`               | `install`                                                     | Install without saving to `skills.json` (for personal skills) |
-| `-g, --global`            | `install`, `uninstall`, `list`                                | Install/manage skills globally (user directory)               |
+| `-g, --global`            | `install`, `uninstall`, `list`, `outdated`                    | Install/manage skills globally (user directory)               |
 | `-a, --agent <agents...>` | `install`                                                     | Specify target agents (e.g., `cursor`, `claude-code`)         |
 | `-a, --agent <agent>`     | `list`                                                        | List skills installed to a specific agent                     |
 | `--mode <mode>`           | `install`                                                     | Installation mode: `symlink` (default) or `copy`              |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,7 +68,7 @@ npx reskill@latest <command>  # 或直接使用 npx
 | 选项                      | 适用命令                                                      | 说明                                         |
 | ------------------------- | ------------------------------------------------------------- | -------------------------------------------- |
 | `--no-save`               | `install`                                                     | 安装时不保存到 `skills.json`（用于个人技能） |
-| `-g, --global`            | `install`, `uninstall`, `list`                                | 全局安装/管理技能（用户目录）                |
+| `-g, --global`            | `install`, `uninstall`, `list`, `outdated`                    | 全局安装/管理技能（用户目录）                |
 | `-a, --agent <agents...>` | `install`                                                     | 指定目标 Agent（如 `cursor`, `claude-code`） |
 | `-a, --agent <agent>`     | `list`                                                        | 列出安装到指定 Agent 的技能                  |
 | `--mode <mode>`           | `install`                                                     | 安装模式：`symlink`（默认）或 `copy`         |

--- a/src/cli/commands/outdated.test.ts
+++ b/src/cli/commands/outdated.test.ts
@@ -70,6 +70,12 @@ describe('outdated command', () => {
       expect(jsonOption?.short).toBe('-j');
     });
 
+    it('should have --global option with -g shortcut', () => {
+      const globalOption = outdatedCommand.options.find((o) => o.long === '--global');
+      expect(globalOption).toBeDefined();
+      expect(globalOption?.short).toBe('-g');
+    });
+
     it('should have no required arguments', () => {
       const args = outdatedCommand.registeredArguments;
       expect(args.length).toBe(0);

--- a/src/cli/commands/outdated.ts
+++ b/src/cli/commands/outdated.ts
@@ -11,26 +11,36 @@ import { logger } from '../../utils/logger.js';
 export const outdatedCommand = new Command('outdated')
   .description('Check for outdated skills')
   .option('-j, --json', 'Output as JSON')
+  .option('-g, --global', 'Check globally installed skills')
   .action(async (options) => {
-    const configLoader = new ConfigLoader();
+    const isGlobal = options.global || false;
 
-    if (!configLoader.exists()) {
-      logger.error("skills.json not found. Run 'reskill init' first.");
-      process.exit(1);
+    if (!isGlobal) {
+      const configLoader = new ConfigLoader();
+
+      if (!configLoader.exists()) {
+        logger.error("skills.json not found. Run 'reskill init' first.");
+        process.exit(1);
+      }
+
+      const skills = configLoader.getSkills();
+      if (Object.keys(skills).length === 0) {
+        logger.info('No skills defined in skills.json');
+        return;
+      }
     }
 
-    const skills = configLoader.getSkills();
-    if (Object.keys(skills).length === 0) {
-      logger.info('No skills defined in skills.json');
-      return;
-    }
-
-    const skillManager = new SkillManager();
+    const skillManager = new SkillManager(undefined, { global: isGlobal });
     const spinner = ora('Checking for updates...').start();
 
     try {
       const results = await skillManager.checkOutdated();
       spinner.stop();
+
+      if (results.length === 0) {
+        logger.info(isGlobal ? 'No globally installed skills found' : 'No skills to check');
+        return;
+      }
 
       if (options.json) {
         console.log(JSON.stringify(results, null, 2));

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GitResolver } from './git-resolver.js';
 import { HttpResolver } from './http-resolver.js';
 import { RegistryResolver } from './registry-resolver.js';
-import { SkillManager } from './skill-manager.js';
+import { deriveDistTag, resolveLatestForChannel, SkillManager } from './skill-manager.js';
 
 describe('SkillManager', () => {
   let tempDir: string;
@@ -3269,6 +3269,323 @@ describe('SkillManager isEffectivelyGlobal behavior for claude-cowork-3p', () =>
 
     const lock = JSON.parse(fs.readFileSync(path.join(tempDir, 'skills.lock'), 'utf-8'));
     expect(lock.skills['test-skill']).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// deriveDistTag tests
+// ============================================================================
+
+describe('deriveDistTag', () => {
+  it('should return "latest" for stable versions', () => {
+    expect(deriveDistTag('1.0.0')).toBe('latest');
+    expect(deriveDistTag('0.1.0')).toBe('latest');
+    expect(deriveDistTag('10.20.30')).toBe('latest');
+  });
+
+  it('should return channel name for prerelease versions', () => {
+    expect(deriveDistTag('1.0.1-alpha.0')).toBe('alpha');
+    expect(deriveDistTag('1.2.4-beta.3')).toBe('beta');
+    expect(deriveDistTag('2.0.0-rc.1')).toBe('rc');
+    expect(deriveDistTag('1.0.0-next.5')).toBe('next');
+  });
+
+  it('should return "next" for numeric-only prerelease', () => {
+    expect(deriveDistTag('1.0.0-0')).toBe('next');
+    expect(deriveDistTag('1.0.0-0.3.7')).toBe('next');
+  });
+
+  it('should ignore build metadata', () => {
+    expect(deriveDistTag('1.0.0+build.123')).toBe('latest');
+    expect(deriveDistTag('1.0.0+2024-01-15')).toBe('latest');
+  });
+
+  it('should handle prerelease with build metadata', () => {
+    expect(deriveDistTag('1.0.1-beta.1+build.5')).toBe('beta');
+  });
+
+  it('should return "latest" for unknown/fallback input', () => {
+    expect(deriveDistTag('unknown')).toBe('latest');
+  });
+});
+
+// ============================================================================
+// resolveLatestForChannel tests
+// ============================================================================
+
+describe('resolveLatestForChannel', () => {
+  it('should return @latest dist-tag for stable version', () => {
+    const info = {
+      latest_version: '1.0.0',
+      dist_tags: [
+        { tag: 'latest', version: '1.1.0' },
+        { tag: 'beta', version: '2.0.0-beta.1' },
+      ],
+    };
+    expect(resolveLatestForChannel('1.0.0', info)).toBe('1.1.0');
+  });
+
+  it('should fall back to latest_version for stable when no dist_tags', () => {
+    const info = { latest_version: '1.2.0' };
+    expect(resolveLatestForChannel('1.0.0', info)).toBe('1.2.0');
+  });
+
+  it('should NOT return beta version for stable user', () => {
+    const info = {
+      latest_version: '1.0.0',
+      dist_tags: [
+        { tag: 'latest', version: '1.0.0' },
+        { tag: 'beta', version: '1.1.0-beta.0' },
+      ],
+    };
+    expect(resolveLatestForChannel('1.0.0', info)).toBe('1.0.0');
+  });
+
+  it('should return channel tag for prerelease version', () => {
+    const info = {
+      latest_version: '0.9.0',
+      dist_tags: [
+        { tag: 'latest', version: '0.9.0' },
+        { tag: 'beta', version: '1.0.0-beta.3' },
+      ],
+    };
+    expect(resolveLatestForChannel('1.0.0-beta.1', info)).toBe('1.0.0-beta.3');
+  });
+
+  it('should NOT fall back to latest_version for prerelease when channel tag missing', () => {
+    const info = {
+      latest_version: '1.0.0',
+      dist_tags: [{ tag: 'latest', version: '1.0.0' }],
+    };
+    expect(resolveLatestForChannel('1.0.0-beta.1', info)).toBeUndefined();
+  });
+
+  it('should return undefined for prerelease when no dist_tags at all', () => {
+    const info = { latest_version: '1.0.0' };
+    expect(resolveLatestForChannel('1.0.0-rc.1', info)).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// checkOutdated registry tests
+// ============================================================================
+
+describe('checkOutdated with registry skills', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reskill-outdated-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function setupProject(
+    skills: Record<string, string>,
+    lockedSkills: Record<string, object>,
+  ): SkillManager {
+    fs.writeFileSync(
+      path.join(tempDir, 'skills.json'),
+      JSON.stringify({ skills, registries: { github: 'https://github.com' }, defaults: {} }),
+    );
+    fs.writeFileSync(
+      path.join(tempDir, 'skills.lock'),
+      JSON.stringify({ lockfileVersion: 1, skills: lockedSkills }),
+    );
+    return new SkillManager(tempDir);
+  }
+
+  it('should detect registry skill with available update', async () => {
+    const manager = setupProject(
+      { 'my-skill': '@kanyun/my-skill@1.0.0' },
+      {
+        'my-skill': {
+          source: 'registry:@kanyun/my-skill',
+          version: '1.0.0',
+          ref: '1.0.0',
+          resolved: 'https://rush-test.zhenguanyu.com',
+          commit: '',
+          registry: 'https://rush-test.zhenguanyu.com',
+        },
+      },
+    );
+
+    const { RegistryClient } = await import('./registry-client.js');
+    vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockResolvedValue({
+      name: '@kanyun/my-skill',
+      latest_version: '1.1.0',
+      dist_tags: [
+        { tag: 'latest', version: '1.1.0' },
+      ],
+    });
+
+    const results = await manager.checkOutdated();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe('my-skill');
+    expect(results[0].current).toBe('1.0.0');
+    expect(results[0].latest).toBe('1.1.0');
+    expect(results[0].updateAvailable).toBe(true);
+
+    vi.restoreAllMocks();
+  });
+
+  it('should report up-to-date for registry skill on latest version', async () => {
+    const manager = setupProject(
+      { 'my-skill': '@kanyun/my-skill@1.0.0' },
+      {
+        'my-skill': {
+          source: 'registry:@kanyun/my-skill',
+          version: '1.0.0',
+          ref: '1.0.0',
+          resolved: 'https://rush-test.zhenguanyu.com',
+          commit: '',
+          registry: 'https://rush-test.zhenguanyu.com',
+        },
+      },
+    );
+
+    const { RegistryClient } = await import('./registry-client.js');
+    vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockResolvedValue({
+      name: '@kanyun/my-skill',
+      latest_version: '1.0.0',
+      dist_tags: [{ tag: 'latest', version: '1.0.0' }],
+    });
+
+    const results = await manager.checkOutdated();
+
+    expect(results[0].updateAvailable).toBe(false);
+
+    vi.restoreAllMocks();
+  });
+
+  it('should check prerelease channel tag instead of latest', async () => {
+    const manager = setupProject(
+      { 'my-skill': '@kanyun/my-skill@1.0.0-beta.1' },
+      {
+        'my-skill': {
+          source: 'registry:@kanyun/my-skill',
+          version: '1.0.0-beta.1',
+          ref: '1.0.0-beta.1',
+          resolved: 'https://rush-test.zhenguanyu.com',
+          commit: '',
+          registry: 'https://rush-test.zhenguanyu.com',
+        },
+      },
+    );
+
+    const { RegistryClient } = await import('./registry-client.js');
+    vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockResolvedValue({
+      name: '@kanyun/my-skill',
+      latest_version: '0.9.0',
+      dist_tags: [
+        { tag: 'latest', version: '0.9.0' },
+        { tag: 'beta', version: '1.0.0-beta.3' },
+      ],
+    });
+
+    const results = await manager.checkOutdated();
+
+    expect(results[0].current).toBe('1.0.0-beta.1');
+    expect(results[0].latest).toBe('1.0.0-beta.3');
+    expect(results[0].updateAvailable).toBe(true);
+
+    vi.restoreAllMocks();
+  });
+
+  it('should not fall back to latest when prerelease channel tag not found', async () => {
+    const manager = setupProject(
+      { 'my-skill': '@kanyun/my-skill@1.0.0-rc.1' },
+      {
+        'my-skill': {
+          source: 'registry:@kanyun/my-skill',
+          version: '1.0.0-rc.1',
+          ref: '1.0.0-rc.1',
+          resolved: 'https://rush-test.zhenguanyu.com',
+          commit: '',
+          registry: 'https://rush-test.zhenguanyu.com',
+        },
+      },
+    );
+
+    const { RegistryClient } = await import('./registry-client.js');
+    vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockResolvedValue({
+      name: '@kanyun/my-skill',
+      latest_version: '1.1.0',
+      dist_tags: [{ tag: 'latest', version: '1.1.0' }],
+    });
+
+    const results = await manager.checkOutdated();
+
+    expect(results[0].latest).toBe('unknown');
+    expect(results[0].updateAvailable).toBe(false);
+
+    vi.restoreAllMocks();
+  });
+
+  it('should not show beta as update for stable version', async () => {
+    const manager = setupProject(
+      { 'my-skill': '@kanyun/my-skill@1.0.0' },
+      {
+        'my-skill': {
+          source: 'registry:@kanyun/my-skill',
+          version: '1.0.0',
+          ref: '1.0.0',
+          resolved: 'https://rush-test.zhenguanyu.com',
+          commit: '',
+          registry: 'https://rush-test.zhenguanyu.com',
+        },
+      },
+    );
+
+    const { RegistryClient } = await import('./registry-client.js');
+    vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockResolvedValue({
+      name: '@kanyun/my-skill',
+      latest_version: '1.0.0',
+      dist_tags: [
+        { tag: 'latest', version: '1.0.0' },
+        { tag: 'beta', version: '1.1.0-beta.0' },
+      ],
+    });
+
+    const results = await manager.checkOutdated();
+
+    expect(results[0].current).toBe('1.0.0');
+    expect(results[0].latest).toBe('1.0.0');
+    expect(results[0].updateAvailable).toBe(false);
+
+    vi.restoreAllMocks();
+  });
+
+  it('should handle registry API failure gracefully', async () => {
+    const manager = setupProject(
+      { 'my-skill': '@kanyun/my-skill@1.0.0' },
+      {
+        'my-skill': {
+          source: 'registry:@kanyun/my-skill',
+          version: '1.0.0',
+          ref: '1.0.0',
+          resolved: 'https://rush-test.zhenguanyu.com',
+          commit: '',
+          registry: 'https://rush-test.zhenguanyu.com',
+        },
+      },
+    );
+
+    const { RegistryClient } = await import('./registry-client.js');
+    vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockRejectedValue(
+      new Error('Network error'),
+    );
+
+    const results = await manager.checkOutdated();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].current).toBe('1.0.0');
+    expect(results[0].latest).toBe('unknown');
+    expect(results[0].updateAvailable).toBe(false);
+
+    vi.restoreAllMocks();
   });
 });
 

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import * as semver from 'semver';
 import type {
   InstalledSkill,
   InstallOptions,
@@ -23,6 +24,7 @@ import {
   getScopeForRegistry,
   getShortName,
   parseSkillIdentifier,
+  REGISTRY_SCOPE_MAP,
   type ScopeRegistries,
 } from '../utils/registry-scope.js';
 import {
@@ -55,6 +57,54 @@ import {
   type ParsedSkillWithPath,
   parseSkillFromDir,
 } from './skill-parser.js';
+
+/**
+ * Derive the dist-tag channel from a semver version string.
+ * Mirrors the server-side deriveDefaultTag logic.
+ *
+ * @internal Exported for testing
+ */
+export function deriveDistTag(version: string): string {
+  const core = version.split('+')[0];
+  const dashIndex = core.indexOf('-');
+  if (dashIndex === -1) {
+    return 'latest';
+  }
+  const channel = core
+    .slice(dashIndex + 1)
+    .split('.')
+    .find((id) => id.length > 0 && !/^\d+$/.test(id));
+  return channel || 'next';
+}
+
+/**
+ * Resolve the latest version for the current version's channel from registry info.
+ *
+ * - Stable channel (latest): prefer dist_tags[@latest], fall back to latest_version.
+ * - Prerelease channel (beta, alpha, …): ONLY use dist_tags[@channel], no fallback.
+ *   A new beta on the registry should not prompt an update for stable users,
+ *   and stable releases should not prompt an update for beta users.
+ *
+ * @internal Exported for testing
+ */
+export function resolveLatestForChannel(
+  currentVersion: string,
+  info: { latest_version?: string; dist_tags?: Array<{ tag: string; version: string }> },
+): string | undefined {
+  const tag = deriveDistTag(currentVersion);
+
+  if (info.dist_tags) {
+    const match = info.dist_tags.find((t) => t.tag === tag)?.version;
+    if (match) return match;
+  }
+
+  // Only fall back to latest_version for the stable channel
+  if (tag === 'latest') {
+    return info.latest_version;
+  }
+
+  return undefined;
+}
 
 /**
  * SkillManager configuration options
@@ -913,9 +963,29 @@ export class SkillManager {
   }
 
   /**
-   * Check for outdated skills
+   * Check for outdated skills.
+   *
+   * In project mode, reads skills.json and skills.lock.
+   * In global mode, scans ~/.agents/skills/ and checks registry for scoped skills.
    */
   async checkOutdated(): Promise<
+    Array<{
+      name: string;
+      current: string;
+      latest: string;
+      updateAvailable: boolean;
+    }>
+  > {
+    if (this.isGlobal) {
+      return this.checkOutdatedGlobal();
+    }
+    return this.checkOutdatedProject();
+  }
+
+  /**
+   * Check for outdated skills in project mode (from skills.json + skills.lock)
+   */
+  private async checkOutdatedProject(): Promise<
     Array<{
       name: string;
       current: string;
@@ -950,7 +1020,15 @@ export class SkillManager {
           continue;
         }
 
-        // Parse latest version
+        // Registry sources - query registry API for latest version
+        if (this.isRegistrySource(ref)) {
+          results.push(
+            await this.checkRegistrySkillUpdate(name, currentVersion, ref, locked?.registry),
+          );
+          continue;
+        }
+
+        // Git sources - parse latest version
         const parsed = this.resolver.parseRef(ref);
         const repoUrl = this.resolver.buildRepoUrl(parsed);
 
@@ -983,6 +1061,155 @@ export class SkillManager {
     }
 
     return results;
+  }
+
+  /**
+   * Check for outdated skills in global mode (scan ~/.agents/skills/)
+   */
+  private async checkOutdatedGlobal(): Promise<
+    Array<{
+      name: string;
+      current: string;
+      latest: string;
+      updateAvailable: boolean;
+    }>
+  > {
+    const installed = this.list();
+    const results: Array<{
+      name: string;
+      current: string;
+      latest: string;
+      updateAvailable: boolean;
+    }> = [];
+
+    const scopeUrls = this.collectScopeRegistries();
+
+    for (const skill of installed) {
+      if (skill.isLinked) {
+        results.push({
+          name: skill.name,
+          current: 'linked',
+          latest: 'n/a',
+          updateAvailable: false,
+        });
+        continue;
+      }
+
+      const currentVersion = skill.version || 'unknown';
+
+      // Scoped names (@scope/name) → direct registry lookup
+      if (skill.name.startsWith('@') && skill.name.includes('/')) {
+        results.push(await this.checkRegistrySkillUpdate(skill.name, currentVersion, skill.name));
+        continue;
+      }
+
+      // Unscoped global skills — probe known registries with @scope/name
+      const probed = await this.probeRegistriesForSkill(skill.name, currentVersion, scopeUrls);
+      results.push(probed);
+    }
+
+    return results;
+  }
+
+  /**
+   * Collect unique scope → URL pairs from config + hardcoded map.
+   */
+  private collectScopeRegistries(): Array<{ scope: string; url: string }> {
+    const seen = new Map<string, string>();
+
+    // From skills.json registries (higher priority)
+    for (const [name, url] of Object.entries(this.config.getRegistries())) {
+      if (name.startsWith('@')) {
+        seen.set(name, url);
+      }
+    }
+
+    // From hardcoded scope map (deduplicate, skip test/localhost)
+    for (const [url, scope] of Object.entries(REGISTRY_SCOPE_MAP)) {
+      if (!seen.has(scope) && !url.includes('localhost') && !scope.includes('-test')) {
+        seen.set(scope, url);
+      }
+    }
+
+    return Array.from(seen, ([scope, url]) => ({ scope, url }));
+  }
+
+  /**
+   * Probe known registries to find an unscoped skill and check for updates.
+   */
+  private async probeRegistriesForSkill(
+    name: string,
+    currentVersion: string,
+    scopeUrls: Array<{ scope: string; url: string }>,
+  ): Promise<{
+    name: string;
+    current: string;
+    latest: string;
+    updateAvailable: boolean;
+  }> {
+    for (const { scope, url } of scopeUrls) {
+      const fullName = `${scope}/${name}`;
+      try {
+        const client = new RegistryClient({ registry: url });
+        const info = await client.getSkillInfo(fullName);
+
+        const latest = resolveLatestForChannel(currentVersion, info);
+        if (!latest) continue;
+
+        const updateAvailable =
+          currentVersion !== 'unknown' &&
+          semver.valid(currentVersion) !== null &&
+          semver.valid(latest) !== null &&
+          semver.gt(latest, currentVersion);
+
+        return { name, current: currentVersion, latest, updateAvailable };
+      } catch {
+        // Not found on this registry, try next
+      }
+    }
+
+    return { name, current: currentVersion, latest: 'n/a (unknown source)', updateAvailable: false };
+  }
+
+  /**
+   * Check a single registry skill for updates.
+   * Prerelease-aware: checks the matching channel tag (beta, alpha, rc, etc.)
+   * instead of @latest when the current version is a prerelease.
+   */
+  private async checkRegistrySkillUpdate(
+    name: string,
+    currentVersion: string,
+    ref: string,
+    cachedRegistryUrl?: string,
+  ): Promise<{
+    name: string;
+    current: string;
+    latest: string;
+    updateAvailable: boolean;
+  }> {
+    try {
+      const parsed = parseSkillIdentifier(ref);
+      const registryUrl = cachedRegistryUrl || (await this.resolveRegistryUrl(ref));
+      const client = new RegistryClient({ registry: registryUrl });
+      const info = await client.getSkillInfo(parsed.fullName);
+
+      const latest = resolveLatestForChannel(currentVersion, info);
+
+      if (!latest) {
+        return { name, current: currentVersion, latest: 'unknown', updateAvailable: false };
+      }
+
+      const updateAvailable =
+        currentVersion !== 'unknown' &&
+        semver.valid(currentVersion) !== null &&
+        semver.valid(latest) !== null &&
+        semver.gt(latest, currentVersion);
+
+      return { name, current: currentVersion, latest, updateAvailable };
+    } catch (error) {
+      logger.debug(`Failed to check registry skill ${name}: ${(error as Error).message}`);
+      return { name, current: currentVersion, latest: 'unknown', updateAvailable: false };
+    }
   }
 
   // ============================================================================

--- a/src/utils/registry-scope.ts
+++ b/src/utils/registry-scope.ts
@@ -15,7 +15,7 @@ export const PUBLIC_REGISTRY = 'https://reskill.info/';
  * Hardcoded registry to scope mapping
  * TODO: Replace with dynamic fetching from /api/registry/info
  */
-const REGISTRY_SCOPE_MAP: Record<string, string> = {
+export const REGISTRY_SCOPE_MAP: Record<string, string> = {
   // rush-app (private registry, new)
   'https://rush-test.zhenguanyu.com': '@kanyun-test',
   'https://rush.zhenguanyu.com': '@kanyun',


### PR DESCRIPTION
## Summary

- **Fix `reskill outdated` 展示不全**: `checkOutdated()` previously only handled Git sources, silently skipping registry-sourced skills (e.g. `@kanyun/xxx`). Added `isRegistrySource()` check to query registry API for latest version.
- **Add `-g, --global` flag**: Scans `~/.agents/skills/` for globally installed skills (which have no `skills.json`/`skills.lock`), probes known registries to find source packages.
- **Prerelease channel isolation**: Stable users (`1.0.0`) only see `@latest` tag updates; prerelease users (`1.0.0-beta.1`) only see their channel tag (`@beta`). No cross-channel noise — a new beta release won't prompt stable users to update.

## Changes

| File | What |
|------|------|
| `src/core/skill-manager.ts` | `deriveDistTag()`, `resolveLatestForChannel()`, split `checkOutdated()` into project/global modes, `checkRegistrySkillUpdate()`, `collectScopeRegistries()`, `probeRegistriesForSkill()` |
| `src/cli/commands/outdated.ts` | `-g, --global` option, global-mode flow |
| `src/utils/registry-scope.ts` | Export `REGISTRY_SCOPE_MAP` for probe logic |
| `src/core/skill-manager.test.ts` | 18 new tests: `deriveDistTag` (6), `resolveLatestForChannel` (6), `checkOutdated` registry integration (6) |
| `src/cli/commands/outdated.test.ts` | `--global` option structure test |
| `README.md` / `README.zh-CN.md` | Add `outdated` to `-g, --global` option docs |

## Test plan

- [x] `deriveDistTag` correctly maps stable → `latest`, prerelease → channel name, numeric-only → `next`
- [x] `resolveLatestForChannel` stable gets `@latest`, prerelease gets channel tag, no cross-channel fallback
- [x] `checkOutdated` detects registry skill updates, reports up-to-date correctly
- [x] Prerelease user not shown stable updates; stable user not shown beta updates
- [x] Registry API failure handled gracefully (returns `unknown`, no crash)
- [x] `-g, --global` option registered on CLI command
- [x] Local manual test: project mode detects registry skills; global mode scans 24 skills and finds updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)