### PR TITLE
feat(core): persist source metadata for global installs and support update -g

### DIFF
--- a/.changeset/source-meta-update-global.md
+++ b/.changeset/source-meta-update-global.md
@@ -1,0 +1,19 @@
+---
+"reskill": minor
+---
+
+feat(core): persist source metadata for global installs and support `update -g`
+
+- Write `.reskill-source.json` in each skill directory during global installs (`-g`, `--no-save`, `--skip-manifest`, claude-3p), recording source, version, and registry URL
+- `outdated -g` reads `.reskill-source.json` first (skipping slow probe), and writes it back after a successful probe for old installs (progressive migration)
+- Add `-g, --global` flag to `update` command, enabling single (`update -g <name>`) and batch (`update -g`) updates for globally installed skills
+- Skills without source metadata are skipped with a helpful message
+
+---
+
+feat(core): 为全局安装持久化来源元数据，支持 `update -g`
+
+- 全局安装（`-g`、`--no-save`、`--skip-manifest`、claude-3p）时在 skill 目录下写入 `.reskill-source.json`，记录来源、版本和 registry URL
+- `outdated -g` 优先读取 `.reskill-source.json`（跳过慢速探测），对老安装在探测成功后自动回写（渐进式迁移）
+- `update` 命令新增 `-g, --global` 参数，支持单个（`update -g <name>`）和批量（`update -g`）更新全局 skill
+- 无来源元数据的 skill 跳过并给出提示

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npx reskill@latest <command>  # Or use npx directly
 | Option                    | Commands                                                      | Description                                                   |
 | ------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------- |
 | `--no-save`               | `install`                                                     | Install without saving to `skills.json` (for personal skills) |
-| `-g, --global`            | `install`, `uninstall`, `list`, `outdated`                    | Install/manage skills globally (user directory)               |
+| `-g, --global`            | `install`, `uninstall`, `list`, `outdated`, `update`          | Install/manage skills globally (user directory)               |
 | `-a, --agent <agents...>` | `install`                                                     | Specify target agents (e.g., `cursor`, `claude-code`)         |
 | `-a, --agent <agent>`     | `list`                                                        | List skills installed to a specific agent                     |
 | `--mode <mode>`           | `install`                                                     | Installation mode: `symlink` (default) or `copy`              |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,7 +68,7 @@ npx reskill@latest <command>  # 或直接使用 npx
 | 选项                      | 适用命令                                                      | 说明                                         |
 | ------------------------- | ------------------------------------------------------------- | -------------------------------------------- |
 | `--no-save`               | `install`                                                     | 安装时不保存到 `skills.json`（用于个人技能） |
-| `-g, --global`            | `install`, `uninstall`, `list`, `outdated`                    | 全局安装/管理技能（用户目录）                |
+| `-g, --global`            | `install`, `uninstall`, `list`, `outdated`, `update`          | 全局安装/管理技能（用户目录）                |
 | `-a, --agent <agents...>` | `install`                                                     | 指定目标 Agent（如 `cursor`, `claude-code`） |
 | `-a, --agent <agent>`     | `list`                                                        | 列出安装到指定 Agent 的技能                  |
 | `--mode <mode>`           | `install`                                                     | 安装模式：`symlink`（默认）或 `copy`         |

--- a/src/cli/commands/update.test.ts
+++ b/src/cli/commands/update.test.ts
@@ -62,6 +62,12 @@ describe('update command', () => {
       expect(updateCommand.description().toLowerCase()).toContain('update');
     });
 
+    it('should have --global option with -g shortcut', () => {
+      const globalOption = updateCommand.options.find((o) => o.long === '--global');
+      expect(globalOption).toBeDefined();
+      expect(globalOption?.short).toBe('-g');
+    });
+
     it('should have optional skill argument', () => {
       const args = updateCommand.registeredArguments;
       expect(args.length).toBe(1);

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -11,15 +11,20 @@ export const updateCommand = new Command('update')
   .alias('up')
   .description('Update installed skills')
   .argument('[skill]', 'Skill name to update (updates all if not specified)')
-  .action(async (skill) => {
-    const configLoader = new ConfigLoader();
+  .option('-g, --global', 'Update globally installed skills')
+  .action(async (skill, options) => {
+    const isGlobal = options.global || false;
 
-    if (!configLoader.exists()) {
-      logger.error("skills.json not found. Run 'reskill init' first.");
-      process.exit(1);
+    if (!isGlobal) {
+      const configLoader = new ConfigLoader();
+
+      if (!configLoader.exists()) {
+        logger.error("skills.json not found. Run 'reskill init' first.");
+        process.exit(1);
+      }
     }
 
-    const skillManager = new SkillManager();
+    const skillManager = new SkillManager(undefined, { global: isGlobal });
     const spinner = ora(skill ? `Updating ${skill}...` : 'Updating all skills...').start();
 
     try {

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GitResolver } from './git-resolver.js';
 import { HttpResolver } from './http-resolver.js';
 import { RegistryResolver } from './registry-resolver.js';
-import { deriveDistTag, resolveLatestForChannel, SkillManager } from './skill-manager.js';
+import { deriveDistTag, readSourceMeta, resolveLatestForChannel, SkillManager, writeSourceMeta } from './skill-manager.js';
 
 describe('SkillManager', () => {
   let tempDir: string;
@@ -3586,6 +3586,173 @@ describe('checkOutdated with registry skills', () => {
     expect(results[0].updateAvailable).toBe(false);
 
     vi.restoreAllMocks();
+  });
+});
+
+// ============================================================================
+// .reskill-source.json tests
+// ============================================================================
+
+describe('reskill source metadata', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reskill-source-meta-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('writeSourceMeta / readSourceMeta', () => {
+    it('should write and read source metadata', () => {
+      const skillDir = path.join(tempDir, 'my-skill');
+      fs.mkdirSync(skillDir, { recursive: true });
+
+      const meta = {
+        source: 'registry:@kanyun/my-skill',
+        version: '1.0.0',
+        registry: 'https://rush.zhenguanyu.com',
+      };
+
+      writeSourceMeta(skillDir, meta);
+
+      const read = readSourceMeta(skillDir);
+      expect(read).not.toBeNull();
+      expect(read!.source).toBe('registry:@kanyun/my-skill');
+      expect(read!.version).toBe('1.0.0');
+      expect(read!.registry).toBe('https://rush.zhenguanyu.com');
+      expect(read!.installedAt).toBeDefined();
+    });
+
+    it('should return null when no source metadata exists', () => {
+      const skillDir = path.join(tempDir, 'no-meta');
+      fs.mkdirSync(skillDir, { recursive: true });
+
+      const read = readSourceMeta(skillDir);
+      expect(read).toBeNull();
+    });
+
+    it('should return null for malformed JSON', () => {
+      const skillDir = path.join(tempDir, 'bad-meta');
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, '.reskill-source.json'), 'not json');
+
+      const read = readSourceMeta(skillDir);
+      expect(read).toBeNull();
+    });
+  });
+
+  describe('checkOutdatedGlobal with source metadata', () => {
+    it('should use .reskill-source.json instead of probing when available', async () => {
+      // Setup global skills dir
+      const globalSkillsDir = path.join(tempDir, '.agents', 'skills');
+      const skillDir = path.join(globalSkillsDir, 'docz');
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: docz\nversion: 0.10.0\ndescription: test\n---\n');
+
+      // Write source metadata
+      writeSourceMeta(skillDir, {
+        source: 'registry:@kanyun/docz',
+        version: '0.10.0',
+        registry: 'https://rush.zhenguanyu.com',
+      });
+
+      // Override HOME so global skills dir resolves to tempDir
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempDir;
+
+      try {
+        const manager = new SkillManager(tempDir, { global: true });
+
+        const { RegistryClient } = await import('./registry-client.js');
+        vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockResolvedValue({
+          name: '@kanyun/docz',
+          latest_version: '0.13.0',
+          dist_tags: [{ tag: 'latest', version: '0.13.0' }],
+        });
+
+        const results = await manager.checkOutdated();
+        const docz = results.find((r) => r.name === 'docz');
+
+        expect(docz).toBeDefined();
+        expect(docz!.current).toBe('0.10.0');
+        expect(docz!.latest).toBe('0.13.0');
+        expect(docz!.updateAvailable).toBe(true);
+      } finally {
+        process.env.HOME = originalHome;
+        vi.restoreAllMocks();
+      }
+    });
+
+    it('should write back source metadata after successful probe', async () => {
+      const globalSkillsDir = path.join(tempDir, '.agents', 'skills');
+      const skillDir = path.join(globalSkillsDir, 'docz');
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: docz\nversion: 0.10.0\ndescription: test\n---\n');
+
+      // No .reskill-source.json — should probe and write back
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempDir;
+
+      try {
+        const manager = new SkillManager(tempDir, { global: true });
+
+        const { RegistryClient } = await import('./registry-client.js');
+        vi.spyOn(RegistryClient.prototype, 'getSkillInfo').mockResolvedValue({
+          name: '@kanyun/docz',
+          latest_version: '0.13.0',
+          dist_tags: [{ tag: 'latest', version: '0.13.0' }],
+        });
+
+        await manager.checkOutdated();
+
+        // Verify .reskill-source.json was written back
+        const meta = readSourceMeta(skillDir);
+        expect(meta).not.toBeNull();
+        expect(meta!.source).toBe('registry:@kanyun/docz');
+        expect(meta!.registry).toBe('https://rush.zhenguanyu.com');
+      } finally {
+        process.env.HOME = originalHome;
+        vi.restoreAllMocks();
+      }
+    });
+  });
+});
+
+// ============================================================================
+// update -g tests
+// ============================================================================
+
+describe('SkillManager updateGlobal', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reskill-update-global-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should skip skills without source metadata', async () => {
+    const globalSkillsDir = path.join(tempDir, '.agents', 'skills');
+    const skillDir = path.join(globalSkillsDir, 'unknown-skill');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: unknown-skill\ndescription: test\n---\n');
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempDir;
+
+    try {
+      const manager = new SkillManager(tempDir, { global: true });
+      const updated = await manager.update();
+
+      expect(updated).toHaveLength(0);
+    } finally {
+      process.env.HOME = originalHome;
+      vi.restoreAllMocks();
+    }
   });
 });
 

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -15,7 +15,9 @@ import {
   isDirectory,
   isSymlink,
   listDir,
+  readJson,
   remove,
+  writeJson,
 } from '../utils/fs.js';
 import { parseGitUrl } from '../utils/git.js';
 import { logger } from '../utils/logger.js';
@@ -104,6 +106,36 @@ export function resolveLatestForChannel(
   }
 
   return undefined;
+}
+
+const SOURCE_META_FILE = '.reskill-source.json';
+
+export interface SourceMeta {
+  source: string;
+  version: string;
+  registry?: string;
+  installedAt: string;
+}
+
+export function writeSourceMeta(
+  skillDir: string,
+  meta: Omit<SourceMeta, 'installedAt'>,
+): void {
+  const data: SourceMeta = {
+    ...meta,
+    installedAt: new Date().toISOString(),
+  };
+  writeJson(path.join(skillDir, SOURCE_META_FILE), data);
+}
+
+export function readSourceMeta(skillDir: string): SourceMeta | null {
+  const filePath = path.join(skillDir, SOURCE_META_FILE);
+  if (!exists(filePath)) return null;
+  try {
+    return readJson<SourceMeta>(filePath);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -578,6 +610,10 @@ export class SkillManager {
    * Update skill
    */
   async update(name?: string): Promise<InstalledSkill[]> {
+    if (this.isGlobal) {
+      return this.updateGlobal(name);
+    }
+
     const updated: InstalledSkill[] = [];
     const targetAgents = await detectInstalledAgents();
 
@@ -638,6 +674,57 @@ export class SkillManager {
         } catch (error) {
           logger.error(`Failed to update ${skillName}: ${(error as Error).message}`);
         }
+      }
+    }
+
+    return updated;
+  }
+
+  /**
+   * Update globally installed skills.
+   * Uses .reskill-source.json to determine the source for each skill.
+   */
+  private async updateGlobal(name?: string): Promise<InstalledSkill[]> {
+    const installed = this.list();
+    const targetAgents = await detectInstalledAgents();
+    const updated: InstalledSkill[] = [];
+
+    const skillsToUpdate = name
+      ? installed.filter((s) => s.name === name)
+      : installed;
+
+    if (name && skillsToUpdate.length === 0) {
+      logger.error(`Skill ${name} not found in global skills`);
+      return [];
+    }
+
+    for (const skill of skillsToUpdate) {
+      if (skill.isLinked) {
+        logger.info(`${skill.name} is linked, skipping`);
+        continue;
+      }
+
+      // Read source metadata
+      const sourceMeta = readSourceMeta(skill.path);
+      if (!sourceMeta?.source) {
+        logger.warn(`${skill.name}: no source metadata, skipping (run 'reskill outdated -g' first to detect sources)`);
+        continue;
+      }
+
+      try {
+        // Reconstruct ref from source metadata
+        const ref = sourceMeta.source.startsWith('registry:')
+          ? sourceMeta.source.slice('registry:'.length)
+          : sourceMeta.source;
+
+        const result = await this.installForUpdate(ref, targetAgents, {
+          force: true,
+          save: false,
+          registry: sourceMeta.registry,
+        });
+        updated.push(result);
+      } catch (error) {
+        logger.error(`Failed to update ${skill.name}: ${(error as Error).message}`);
       }
     }
 
@@ -1097,6 +1184,19 @@ export class SkillManager {
 
       const currentVersion = skill.version || 'unknown';
 
+      // Try .reskill-source.json first (written on install or by previous probe)
+      const sourceMeta = readSourceMeta(skill.path);
+      if (sourceMeta?.source?.startsWith('registry:')) {
+        const result = await this.checkRegistrySkillUpdate(
+          skill.name,
+          currentVersion,
+          sourceMeta.source.slice('registry:'.length),
+          sourceMeta.registry,
+        );
+        results.push(result);
+        continue;
+      }
+
       // Scoped names (@scope/name) → direct registry lookup
       if (skill.name.startsWith('@') && skill.name.includes('/')) {
         results.push(await this.checkRegistrySkillUpdate(skill.name, currentVersion, skill.name));
@@ -1104,7 +1204,7 @@ export class SkillManager {
       }
 
       // Unscoped global skills — probe known registries with @scope/name
-      const probed = await this.probeRegistriesForSkill(skill.name, currentVersion, scopeUrls);
+      const probed = await this.probeRegistriesForSkill(skill.name, currentVersion, scopeUrls, skill.path);
       results.push(probed);
     }
 
@@ -1141,6 +1241,7 @@ export class SkillManager {
     name: string,
     currentVersion: string,
     scopeUrls: Array<{ scope: string; url: string }>,
+    skillPath?: string,
   ): Promise<{
     name: string;
     current: string;
@@ -1161,6 +1262,19 @@ export class SkillManager {
           semver.valid(currentVersion) !== null &&
           semver.valid(latest) !== null &&
           semver.gt(latest, currentVersion);
+
+        // Write back source metadata for future lookups
+        if (skillPath) {
+          try {
+            writeSourceMeta(skillPath, {
+              source: `registry:${fullName}`,
+              version: currentVersion,
+              registry: url,
+            });
+          } catch {
+            // Non-critical, skip silently
+          }
+        }
 
         return { name, current: currentVersion, latest, updateAvailable };
       } catch {
@@ -1429,6 +1543,18 @@ export class SkillManager {
         this.config.addSkill(skillInfo.name, `${baseRefForSave}#${skillInfo.name}`);
       }
 
+      if (effectivelyGlobal) {
+        const skillInstallPath = this.getSkillPath(skillInfo.name);
+        try {
+          writeSourceMeta(skillInstallPath, {
+            source: skillSource,
+            version: semanticVersion,
+          });
+        } catch {
+          // Non-critical
+        }
+      }
+
       const successCount = Array.from(results.values()).filter((r) => r.success).length;
       logger.success(`Installed ${skillInfo.name}@${semanticVersion} to ${successCount} agent(s)`);
 
@@ -1501,10 +1627,9 @@ export class SkillManager {
 
     // Update lock file (project mode only, skip for effectively-global installs)
     const effectivelyGlobal = this.isEffectivelyGlobal(targetAgents);
+    const gitSource = `${parsed.registry}:${parsed.owner}/${parsed.repo}${parsed.subPath ? `/${parsed.subPath}` : ''}`;
     if (!effectivelyGlobal) {
-      const lockSource =
-        registryContext?.lockSource ??
-        `${parsed.registry}:${parsed.owner}/${parsed.repo}${parsed.subPath ? `/${parsed.subPath}` : ''}`;
+      const lockSource = registryContext?.lockSource ?? gitSource;
       this.lockManager.lockSkill(skillName, {
         source: lockSource,
         version: semanticVersion,
@@ -1520,6 +1645,20 @@ export class SkillManager {
       this.config.ensureExists();
       const configRef = registryContext?.configRef ?? this.config.normalizeSkillRef(ref);
       this.config.addSkill(skillName, configRef);
+    }
+
+    // Write source metadata for global installs
+    if (effectivelyGlobal) {
+      const skillPath = this.getSkillPath(skillName);
+      try {
+        writeSourceMeta(skillPath, {
+          source: registryContext?.lockSource ?? gitSource,
+          version: semanticVersion,
+          registry: registryContext?.registryUrl,
+        });
+      } catch {
+        // Non-critical
+      }
     }
 
     // Count results
@@ -1540,7 +1679,7 @@ export class SkillManager {
       name: skillName,
       path: sourcePath,
       version: semanticVersion,
-      source: `${parsed.registry}:${parsed.owner}/${parsed.repo}${parsed.subPath ? `/${parsed.subPath}` : ''}`,
+      source: gitSource,
     };
 
     return { skill, results };
@@ -1602,8 +1741,9 @@ export class SkillManager {
 
     // Update lock file (project mode only, skip for effectively-global installs)
     const effectivelyGlobal = this.isEffectivelyGlobal(targetAgents);
+    const httpSource = `http:${httpInfo.host}/${skillName}`;
     if (!effectivelyGlobal) {
-      const lockSource = registryContext?.lockSource ?? `http:${httpInfo.host}/${skillName}`;
+      const lockSource = registryContext?.lockSource ?? httpSource;
       this.lockManager.lockSkill(skillName, {
         source: lockSource,
         version: semanticVersion,
@@ -1619,6 +1759,20 @@ export class SkillManager {
       this.config.ensureExists();
       const configRef = registryContext?.configRef ?? ref;
       this.config.addSkill(skillName, configRef);
+    }
+
+    // Write source metadata for global installs
+    if (effectivelyGlobal) {
+      const skillInstallPath = this.getSkillPath(skillName);
+      try {
+        writeSourceMeta(skillInstallPath, {
+          source: registryContext?.lockSource ?? httpSource,
+          version: semanticVersion,
+          registry: registryContext?.registryUrl,
+        });
+      } catch {
+        // Non-critical
+      }
     }
 
     // Count results
@@ -1640,7 +1794,7 @@ export class SkillManager {
       name: skillName,
       path: sourcePath,
       version: semanticVersion,
-      source: `http:${httpInfo.host}/${skillName}`,
+      source: httpSource,
     };
 
     return { skill, results };
@@ -1853,6 +2007,20 @@ export class SkillManager {
             this.config.addRegistry(registryName, options.registry);
             this.config.save();
           }
+        }
+      }
+
+      // Write source metadata for global installs
+      if (effectivelyGlobal) {
+        const skillInstallPath = this.getSkillPath(shortName);
+        try {
+          writeSourceMeta(skillInstallPath, {
+            source: `registry:${resolvedParsed.fullName}`,
+            version,
+            registry: resolvedRegistryUrl,
+          });
+        } catch {
+          // Non-critical
         }
       }
 
@@ -2104,6 +2272,20 @@ export class SkillManager {
             this.config.addRegistry(registryName, options.registry);
             this.config.save();
           }
+        }
+      }
+
+      // Write source metadata for global installs
+      if (effectivelyGlobal) {
+        const skillInstallPath = this.getSkillPath(skillName);
+        try {
+          writeSourceMeta(skillInstallPath, {
+            source: `registry:${parsed.fullName}`,
+            version: semanticVersion,
+            registry: registryUrl,
+          });
+        } catch {
+          // Non-critical
         }
       }
 


### PR DESCRIPTION
## Summary

- **`.reskill-source.json`**: 全局安装（`-g`、`--no-save`、`--skip-manifest`、claude-3p）时在 skill 目录下写入来源元数据，记录 source、version、registry URL
- **`outdated -g` 优化**: 优先读取 `.reskill-source.json`（跳过慢速 probe），对历史安装在 probe 成功后自动回写（渐进式迁移）
- **`update -g` 支持**: 新增 `-g, --global` 参数，支持单个（`update -g <name>`）和批量（`update -g`）更新全局 skill

## Changes

| File | What |
|------|------|
| `src/core/skill-manager.ts` | `writeSourceMeta()`/`readSourceMeta()`, 5 个 install 路径写入元数据, `checkOutdatedGlobal` 读取/回写, `updateGlobal()` |
| `src/cli/commands/update.ts` | `-g, --global` option, global-mode flow |
| `src/core/skill-manager.test.ts` | 6 new tests: writeSourceMeta/readSourceMeta (3), checkOutdatedGlobal with metadata (2), updateGlobal skip (1) |
| `src/cli/commands/update.test.ts` | `--global` option structure test |
| `README.md` / `README.zh-CN.md` | Add `update` to `-g, --global` option docs |

## Test plan

- [x] `writeSourceMeta`/`readSourceMeta` write, read, and handle malformed JSON
- [x] `checkOutdatedGlobal` reads `.reskill-source.json` instead of probing
- [x] `checkOutdatedGlobal` writes back metadata after successful probe
- [x] `updateGlobal` skips skills without source metadata with helpful message
- [x] `-g, --global` option registered on `update` CLI command
- [x] Local: `install -g @kanyun/docz@0.10.0` writes `.reskill-source.json`
- [x] Local: `update -g docz` reads metadata and updates 0.10.0 → 0.13.0
- [x] Local: `outdated -g` after update shows all up to date
- [x] Local: `update -g find-skills` (no metadata) skips with message
- [x] Full test suite: 1549 pass, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)