### PR TITLE
feat(cli): add --base-dir to relocate the project root

### DIFF
--- a/.changeset/base-dir-option.md
+++ b/.changeset/base-dir-option.md
@@ -1,0 +1,21 @@
+---
+"reskill": minor
+---
+
+feat(cli): add `--base-dir` to relocate the project root
+
+- New `--base-dir <dir>` option on `install`, `list`, `update`, `outdated` and `uninstall`. It overrides the project root that project-level operations resolve against, so `skills.json`, `skills.lock` and every target agent's skills directory move together — `--base-dir agents/foo -a claude-code cursor` reads `agents/foo/skills.json` and installs into `agents/foo/.claude/skills` and `agents/foo/.cursor/skills`
+- This makes per-instance isolation possible: several agent definitions can live side by side under one parent directory, each with an independent skill set, without the current working directory or `~/.claude/skills` being shared between them. Previously the only options were the current directory (project-level) or the user home directory (`-g`), and neither could express "this agent's own skill set"
+- The underlying `SkillManager`/`ConfigLoader`/`getAgentSkillsDir` already accepted a project root; the CLI simply never exposed it. No path-resolution logic was changed, so default behavior without the flag is unchanged
+- Validation: the directory must already exist (creating it on demand would turn a typo into an empty skill set that fails much later), must be a directory rather than a file, and cannot be combined with `-g/--global`, which always resolves to the user home directory. All failures exit with code 1
+- Note: the global cache is not concurrency-safe, so multiple roots should be installed sequentially. This is a pre-existing limitation tracked separately
+
+---
+
+feat(cli): 新增 `--base-dir` 参数，可重定向项目根目录
+
+- 在 `install`、`list`、`update`、`outdated`、`uninstall` 上新增 `--base-dir <dir>` 参数。它覆盖项目级操作所基于的项目根目录，`skills.json`、`skills.lock` 与各目标 agent 的 skills 目录会一起迁移——`--base-dir agents/foo -a claude-code cursor` 会读取 `agents/foo/skills.json`，并安装到 `agents/foo/.claude/skills` 和 `agents/foo/.cursor/skills`
+- 这使得按实例隔离成为可能：多个 agent 定义可以并存于同一个父目录下，各自拥有独立的 skill 集合，既不共享当前工作目录，也不共享 `~/.claude/skills`。此前只有当前目录（项目级）和用户主目录（`-g`）两个选择，都无法表达"这个 agent 自己的 skill 集合"
+- 底层的 `SkillManager`/`ConfigLoader`/`getAgentSkillsDir` 本就接受项目根目录参数，只是 CLI 从未暴露出来。本次未改动任何路径解析逻辑，不带该参数时行为完全不变
+- 参数校验：目录必须已存在（若按需创建，一个笔误会变成空的 skill 集合，问题要到很久之后才暴露）、必须是目录而非文件、且不能与 `-g/--global` 同时使用（全局安装始终解析到用户主目录）。所有校验失败均以退出码 1 结束
+- 注意：全局缓存并非并发安全，多个根目录应串行安装。这是既有限制，另行跟踪

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ npx reskill@latest <command>  # Or use npx directly
 | `-s, --skill <names...>`  | `install`                                                     | Select specific skill(s) by name from a multi-skill repo      |
 | `--list`                  | `install`                                                     | List available skills in the repository without installing     |
 | `--skip-manifest`         | `install`                                                     | Skip all `skills.json` and `skills.lock` writes (for platform integration) |
+| `--base-dir <dir>`        | `install`, `uninstall`, `list`, `outdated`, `update`          | Project root to resolve `skills.json`, `skills.lock` and agent skill directories against |
 | `-t, --token <token>`     | `install`, `find`, `group`, `publish`, `login`                | Auth token for registry API requests (for CI/CD)               |
 | `-r, --registry <url>`    | `install`, `find`, `group`, `publish`, `login`, `logout`, `whoami` | Registry URL override for registry-enabled commands       |
 | `--tag <tag>`             | `publish`                                                     | Git tag to publish                                             |
@@ -248,6 +249,61 @@ Skills are installed to `.skills/` by default and can be integrated with any age
 | Roo Code       | `.roo/skills`      |
 | Trae           | `.trae/skills`     |
 | Windsurf       | `.windsurf/skills` |
+
+### Isolated Project Roots
+
+By default, project-level commands resolve everything against the current
+directory. `--base-dir` points them at a different project root instead —
+`skills.json`, `skills.lock` and every agent directory move together:
+
+```bash
+# Installs into ./agents/foo/.claude/skills and ./agents/foo/.cursor/skills,
+# reading and writing ./agents/foo/skills.json
+reskill install github:user/skill --base-dir agents/foo -a claude-code cursor
+```
+
+This is useful when several agent definitions live side by side on one machine
+and each needs its own skill set:
+
+```
+agents/
+├── foo/
+│   ├── skills.json          # foo's dependencies
+│   ├── .claude/skills/      # foo's skills
+│   └── .cursor/skills/
+└── bar/
+    ├── skills.json          # bar's dependencies, independent of foo
+    └── .claude/skills/
+```
+
+Install into each root separately — one `reskill` call per root:
+
+```bash
+reskill install github:user/skill-a --base-dir agents/foo -a claude-code -y
+reskill install github:user/skill-b --base-dir agents/bar -a claude-code -y
+```
+
+> **Run these sequentially.** The global cache is not concurrency-safe: two
+> `reskill` processes installing the same skill version at the same time can
+> interfere with each other.
+
+The same flag works for reading back and maintaining each root:
+
+```bash
+reskill list --base-dir agents/foo
+reskill outdated --base-dir agents/foo
+reskill update --base-dir agents/foo
+reskill uninstall skill-a --base-dir agents/foo
+```
+
+To let a runtime pick these skills up, point its own config root at the matching
+directory — for Claude Code, `CLAUDE_CONFIG_DIR=agents/foo/.claude`.
+
+Notes:
+
+- The directory must already exist; reskill will not create it.
+- `--base-dir` cannot be combined with `-g/--global`, which always resolves to
+  the user home directory.
 
 ## Publishing Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,6 +78,7 @@ npx reskill@latest <command>  # 或直接使用 npx
 | `-s, --skill <names...>`  | `install`                                                     | 从多 skill 仓库中选择指定 skill              |
 | `--list`                  | `install`                                                     | 列出仓库中可用的 skills（不安装）            |
 | `--skip-manifest`         | `install`                                                     | 跳过 `skills.json` 和 `skills.lock` 写入（用于平台集成） |
+| `--base-dir <dir>`        | `install`, `uninstall`, `list`, `outdated`, `update`          | 指定项目根目录，`skills.json`、`skills.lock` 与各 Agent 的 skills 目录都基于它解析 |
 | `-t, --token <token>`     | `install`, `find`, `group`, `publish`, `login`                | 认证令牌（用于 CI/CD 访问私有 skill）        |
 | `-r, --registry <url>`    | `install`, `find`, `group`, `publish`, `login`, `logout`, `whoami` | 覆盖 registry URL（用于 registry 相关命令）  |
 | `--tag <tag>`             | `publish`                                                     | 发布的 Git tag                               |
@@ -248,6 +249,54 @@ Skills 默认安装到 `.skills/`，可与任何 Agent 集成：
 | Roo Code       | `.roo/skills`      |
 | Trae           | `.trae/skills`     |
 | Windsurf       | `.windsurf/skills` |
+
+### 隔离的项目根目录
+
+默认情况下，项目级命令都基于当前目录解析路径。`--base-dir` 可以把它们指向另一个项目根目录——`skills.json`、`skills.lock` 和各 Agent 目录会一起迁移：
+
+```bash
+# 安装到 ./agents/foo/.claude/skills 和 ./agents/foo/.cursor/skills，
+# 并读写 ./agents/foo/skills.json
+reskill install github:user/skill --base-dir agents/foo -a claude-code cursor
+```
+
+当同一台机器上并存多个 agent 定义、每个都需要自己的 skill 集合时，这个参数很有用：
+
+```
+agents/
+├── foo/
+│   ├── skills.json          # foo 的依赖
+│   ├── .claude/skills/      # foo 的 skills
+│   └── .cursor/skills/
+└── bar/
+    ├── skills.json          # bar 的依赖，与 foo 互相独立
+    └── .claude/skills/
+```
+
+对每个根目录分别安装——一个根目录一次 `reskill` 调用：
+
+```bash
+reskill install github:user/skill-a --base-dir agents/foo -a claude-code -y
+reskill install github:user/skill-b --base-dir agents/bar -a claude-code -y
+```
+
+> **请串行执行。** 全局缓存并非并发安全：两个 `reskill` 进程同时安装同一个 skill 版本可能互相干扰。
+
+读取和维护各个根目录同样使用这个参数：
+
+```bash
+reskill list --base-dir agents/foo
+reskill outdated --base-dir agents/foo
+reskill update --base-dir agents/foo
+reskill uninstall skill-a --base-dir agents/foo
+```
+
+若要让 runtime 识别这些 skills，把它自己的配置根目录指向对应位置——以 Claude Code 为例即 `CLAUDE_CONFIG_DIR=agents/foo/.claude`。
+
+注意事项：
+
+- 目录必须已存在，reskill 不会自动创建。
+- `--base-dir` 不能与 `-g/--global` 同时使用，全局安装始终解析到用户主目录。
 
 ## 发布 Skills
 

--- a/src/cli/commands/__integration__/install-base-dir.test.ts
+++ b/src/cli/commands/__integration__/install-base-dir.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Integration tests for the --base-dir option
+ *
+ * --base-dir relocates the project root that skills.json, skills.lock and every
+ * agent's skills directory resolve against. This is what lets a host keep
+ * several agent definitions side by side under one parent directory and install
+ * an independent skill set into each of them.
+ *
+ * Layout under test:
+ *
+ *   <temp>/agents/foo/.claude/skills/<skill>
+ *   <temp>/agents/foo/.cursor/skills/<skill>
+ *   <temp>/agents/foo/skills.json
+ *   <temp>/agents/bar/...            (independent)
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createLocalGitRepo,
+  createTempDir,
+  getOutput,
+  pathExists,
+  removeTempDir,
+  runCli,
+} from './helpers.js';
+
+describe('CLI Integration: install --base-dir', () => {
+  let tempDir: string;
+  let repoUrl: string;
+  let fooDir: string;
+  let barDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    fooDir = path.join(tempDir, 'agents', 'foo');
+    barDir = path.join(tempDir, 'agents', 'bar');
+    fs.mkdirSync(fooDir, { recursive: true });
+    fs.mkdirSync(barDir, { recursive: true });
+    repoUrl = createLocalGitRepo(tempDir, 'demo-skill');
+  });
+
+  afterEach(() => {
+    removeTempDir(tempDir);
+  });
+
+  describe('help output', () => {
+    it('should advertise --base-dir on install', () => {
+      const { stdout, exitCode } = runCli('install --help', tempDir);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('--base-dir');
+    });
+
+    it.each([
+      'list',
+      'update',
+      'outdated',
+      'uninstall',
+    ])('should advertise --base-dir on %s', (command) => {
+      const { stdout, exitCode } = runCli(`${command} --help`, tempDir);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('--base-dir');
+    });
+  });
+
+  describe('installing into a relocated project root', () => {
+    it('should install into the base dir instead of the current directory', () => {
+      const { exitCode } = runCli(
+        `install ${repoUrl}@v1.0.0 --base-dir agents/foo -a claude-code -y`,
+        tempDir,
+      );
+
+      expect(exitCode).toBe(0);
+      expect(pathExists(path.join(fooDir, '.claude/skills/demo-skill'))).toBe(true);
+    });
+
+    it('should leave the current directory untouched', () => {
+      runCli(`install ${repoUrl}@v1.0.0 --base-dir agents/foo -a claude-code -y`, tempDir);
+
+      expect(pathExists(path.join(tempDir, '.claude'))).toBe(false);
+      expect(pathExists(path.join(tempDir, 'skills.json'))).toBe(false);
+    });
+
+    it('should write skills.json and skills.lock inside the base dir', () => {
+      runCli(`install ${repoUrl}@v1.0.0 --base-dir agents/foo -a claude-code -y`, tempDir);
+
+      expect(pathExists(path.join(fooDir, 'skills.json'))).toBe(true);
+      expect(pathExists(path.join(fooDir, 'skills.lock'))).toBe(true);
+    });
+
+    it('should keep each agent layout under one base dir when several are targeted', () => {
+      const { exitCode } = runCli(
+        `install ${repoUrl}@v1.0.0 --base-dir agents/foo -a claude-code cursor -y`,
+        tempDir,
+      );
+
+      expect(exitCode).toBe(0);
+      expect(pathExists(path.join(fooDir, '.claude/skills/demo-skill'))).toBe(true);
+      expect(pathExists(path.join(fooDir, '.cursor/skills/demo-skill'))).toBe(true);
+    });
+
+    it('should accept an absolute base dir', () => {
+      const { exitCode } = runCli(
+        `install ${repoUrl}@v1.0.0 --base-dir ${fooDir} -a claude-code -y`,
+        tempDir,
+      );
+
+      expect(exitCode).toBe(0);
+      expect(pathExists(path.join(fooDir, '.claude/skills/demo-skill'))).toBe(true);
+    });
+  });
+
+  describe('isolation between sibling base dirs', () => {
+    it('should not leak an install from one base dir into its sibling', () => {
+      runCli(`install ${repoUrl}@v1.0.0 --base-dir agents/foo -a claude-code -y`, tempDir);
+
+      expect(pathExists(path.join(fooDir, '.claude/skills/demo-skill'))).toBe(true);
+      expect(pathExists(path.join(barDir, '.claude'))).toBe(false);
+      expect(pathExists(path.join(barDir, 'skills.json'))).toBe(false);
+    });
+
+    it('should let sibling base dirs hold different agent sets', () => {
+      runCli(`install ${repoUrl}@v1.0.0 --base-dir agents/foo -a claude-code cursor -y`, tempDir);
+      runCli(`install ${repoUrl}@v1.0.0 --base-dir agents/bar -a claude-code -y`, tempDir);
+
+      expect(pathExists(path.join(fooDir, '.cursor/skills/demo-skill'))).toBe(true);
+      // bar never targeted cursor, so it must not have gained that directory
+      expect(pathExists(path.join(barDir, '.cursor/skills/demo-skill'))).toBe(false);
+      expect(pathExists(path.join(barDir, '.claude/skills/demo-skill'))).toBe(true);
+    });
+  });
+
+  describe('list reads back from the same base dir', () => {
+    it('should list the skill installed into that base dir', () => {
+      runCli(`install ${repoUrl}@v1.0.0 --base-dir agents/foo -a claude-code -y`, tempDir);
+
+      const { stdout, exitCode } = runCli('list --base-dir agents/foo', tempDir);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('demo-skill');
+    });
+
+    it('should report nothing for a sibling base dir', () => {
+      runCli(`install ${repoUrl}@v1.0.0 --base-dir agents/foo -a claude-code -y`, tempDir);
+
+      const { stdout } = runCli('list --base-dir agents/bar', tempDir);
+      expect(stdout).not.toContain('demo-skill');
+    });
+
+    it('should report nothing for the current directory', () => {
+      runCli(`install ${repoUrl}@v1.0.0 --base-dir agents/foo -a claude-code -y`, tempDir);
+
+      const { stdout } = runCli('list', tempDir);
+      expect(stdout).not.toContain('demo-skill');
+    });
+  });
+
+  describe('rejecting invalid usage', () => {
+    it.each([
+      'install some-skill',
+      'list',
+      'update',
+      'outdated',
+      'uninstall some-skill',
+    ])('should exit 1 for a missing base dir on `%s`', (command) => {
+      const { exitCode } = runCli(`${command} --base-dir agents/nope -y`, tempDir);
+      expect(exitCode).toBe(1);
+    });
+
+    it('should explain that the base dir was not found', () => {
+      const result = runCli('list --base-dir agents/nope', tempDir);
+      expect(getOutput(result)).toContain('--base-dir directory not found');
+    });
+
+    it('should reject --base-dir combined with --global', () => {
+      const result = runCli('list --base-dir agents/foo -g', tempDir);
+      expect(result.exitCode).toBe(1);
+      expect(getOutput(result)).toContain('cannot be combined with --global');
+    });
+
+    it('should reject a base dir that points at a file', () => {
+      const filePath = path.join(tempDir, 'not-a-dir.txt');
+      fs.writeFileSync(filePath, 'x');
+
+      const result = runCli(`list --base-dir ${filePath}`, tempDir);
+      expect(result.exitCode).toBe(1);
+      expect(getOutput(result)).toContain('must point to a directory');
+    });
+  });
+});

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -7,6 +7,7 @@ import { CLAUDE_COWORK_3P_AGENT } from '../../core/claude-3p-installer.js';
 import { ConfigLoader } from '../../core/config-loader.js';
 import type { InstallMode } from '../../core/installer.js';
 import { SkillManager } from '../../core/skill-manager.js';
+import { BASE_DIR_OPTION_DESCRIPTION, resolveBaseDir } from '../../utils/base-dir.js';
 import { shortenPath } from '../../utils/fs.js';
 
 // ============================================================================
@@ -31,6 +32,8 @@ interface InstallOptions {
   token?: string;
   /** Skip all skills.json and skills.lock writes (for platform integration) */
   skipManifest?: boolean;
+  /** Project root to resolve manifest, lock and agent skill directories against */
+  baseDir?: string;
 }
 
 interface InstallContext {
@@ -46,6 +49,8 @@ interface InstallContext {
   isBatchInstall: boolean;
   skipConfirm: boolean;
   skipManifest: boolean;
+  /** Resolved absolute project root, or undefined to use process.cwd() */
+  baseDir: string | undefined;
 }
 
 // ============================================================================
@@ -91,7 +96,10 @@ function filterValidAgents(
  * Create install context from command arguments and options
  */
 function createInstallContext(skills: string[], options: InstallOptions): InstallContext {
-  const configLoader = new ConfigLoader();
+  // Resolve --base-dir first: it decides where skills.json is read from, so it
+  // must be settled before the config loader looks for one.
+  const baseDir = resolveBaseDir(options.baseDir, { global: options.global });
+  const configLoader = new ConfigLoader(baseDir);
   const allAgentTypes = Object.keys(agents) as AgentType[];
   const hasSkillsJson = configLoader.exists();
 
@@ -113,6 +121,7 @@ function createInstallContext(skills: string[], options: InstallOptions): Instal
     isBatchInstall: skills.length > 1,
     skipConfirm: options.yes ?? false,
     skipManifest: options.skipManifest ?? false,
+    baseDir,
   };
 }
 
@@ -271,10 +280,7 @@ async function resolveInstallScope(
   }
 
   // claude-cowork-3p always installs globally — skip prompt
-  if (
-    targetAgents.length > 0 &&
-    targetAgents.every((a) => a === CLAUDE_COWORK_3P_AGENT)
-  ) {
+  if (targetAgents.length > 0 && targetAgents.every((a) => a === CLAUDE_COWORK_3P_AGENT)) {
     p.log.info('Using global scope (claude-cowork-3p is always global)');
     return true;
   }
@@ -328,10 +334,7 @@ async function resolveInstallMode(
   }
 
   // claude-cowork-3p always uses copy mode — skip prompt
-  if (
-    targetAgents.length > 0 &&
-    targetAgents.every((a) => a === CLAUDE_COWORK_3P_AGENT)
-  ) {
+  if (targetAgents.length > 0 && targetAgents.every((a) => a === CLAUDE_COWORK_3P_AGENT)) {
     return 'copy';
   }
 
@@ -403,14 +406,14 @@ async function installAllSkills(
   displayInstallSummary({
     skillCount: Object.keys(skills).length,
     agentCount: targetAgents.length,
-    scope: 'Project (./) ',
+    scope: ctx.baseDir ? `Project (${shortenPath(ctx.baseDir)})` : 'Project (./) ',
     mode: installMode,
   });
 
   // Execute installation (no confirmation for reinstall all)
   spinner.start('Installing skills...');
 
-  const skillManager = new SkillManager(undefined, {
+  const skillManager = new SkillManager(ctx.baseDir, {
     global: false,
     noManifest: ctx.skipManifest,
   });
@@ -466,7 +469,7 @@ async function installSingleSkill(
   const skill = skills[0];
   const cwd = process.cwd();
 
-  const skillManager = new SkillManager(undefined, {
+  const skillManager = new SkillManager(ctx.baseDir, {
     global: installGlobally,
     noManifest: ctx.skipManifest,
   });
@@ -631,7 +634,7 @@ async function installMultiSkillFromRepo(
   installMode: InstallMode,
   spinner: ReturnType<typeof p.spinner>,
 ): Promise<void> {
-  const skillManager = new SkillManager(undefined, {
+  const skillManager = new SkillManager(ctx.baseDir, {
     global: installGlobally,
     noManifest: ctx.skipManifest,
   });
@@ -742,7 +745,7 @@ async function installMultipleSkills(
   }
 
   // Execute installation for all skills in parallel
-  const skillManager = new SkillManager(undefined, {
+  const skillManager = new SkillManager(ctx.baseDir, {
     global: installGlobally,
     noManifest: ctx.skipManifest,
   });
@@ -998,6 +1001,7 @@ export const installCommand = new Command('install')
     '--skip-manifest',
     'Skip all skills.json and skills.lock writes (for platform integration)',
   )
+  .option('--base-dir <dir>', BASE_DIR_OPTION_DESCRIPTION)
   .action(async (skills: string[], options: InstallOptions) => {
     // Handle --all flag implications
     if (options.all) {
@@ -1019,14 +1023,15 @@ export const installCommand = new Command('install')
       options.skipManifest = true;
     }
 
-    // Create execution context
-    const ctx = createInstallContext(skills, options);
-
     // Print banner
     console.log();
     p.intro(chalk.bgCyan.black(' reskill '));
 
     try {
+      // Built inside the try so --base-dir validation failures surface through
+      // the same error path as the rest of the install.
+      const ctx = createInstallContext(skills, options);
+
       const spinner = p.spinner();
 
       // Multi-skill path (single ref + --skill or --list): list only skips scope/mode/agents

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { type AgentType, getAgentConfig, isValidAgentType } from '../../core/agent-registry.js';
 import { CLAUDE_COWORK_3P_AGENT } from '../../core/claude-3p-installer.js';
 import { SkillManager } from '../../core/skill-manager.js';
+import { BASE_DIR_OPTION_DESCRIPTION, resolveBaseDirOrExit } from '../../utils/base-dir.js';
 import { logger } from '../../utils/logger.js';
 
 /**
@@ -13,6 +14,7 @@ export const listCommand = new Command('list')
   .option('-j, --json', 'Output as JSON')
   .option('-g, --global', 'List globally installed skills')
   .option('-a, --agent <agent>', 'List skills installed to a specific agent')
+  .option('--base-dir <dir>', BASE_DIR_OPTION_DESCRIPTION)
   .action((options) => {
     const agentInput: string | undefined = options.agent;
 
@@ -25,7 +27,8 @@ export const listCommand = new Command('list')
 
     // claude-cowork-3p is always global
     const isGlobal = options.global || agent === CLAUDE_COWORK_3P_AGENT;
-    const skillManager = new SkillManager(undefined, { global: isGlobal });
+    const baseDir = resolveBaseDirOrExit(options.baseDir, { global: isGlobal });
+    const skillManager = new SkillManager(baseDir, { global: isGlobal });
     const skills = skillManager.list(agent ? { agent } : undefined);
 
     if (skills.length === 0) {
@@ -43,11 +46,7 @@ export const listCommand = new Command('list')
       return;
     }
 
-    const scopeLabel = agent
-      ? getAgentConfig(agent).displayName
-      : isGlobal
-        ? 'global'
-        : 'project';
+    const scopeLabel = agent ? getAgentConfig(agent).displayName : isGlobal ? 'global' : 'project';
     logger.log(`Installed Skills (${scopeLabel}):`);
     logger.newline();
 

--- a/src/cli/commands/outdated.ts
+++ b/src/cli/commands/outdated.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import ora from 'ora';
 import { ConfigLoader } from '../../core/config-loader.js';
 import { SkillManager } from '../../core/skill-manager.js';
+import { BASE_DIR_OPTION_DESCRIPTION, resolveBaseDirOrExit } from '../../utils/base-dir.js';
 import { logger } from '../../utils/logger.js';
 
 /**
@@ -12,11 +13,13 @@ export const outdatedCommand = new Command('outdated')
   .description('Check for outdated skills')
   .option('-j, --json', 'Output as JSON')
   .option('-g, --global', 'Check globally installed skills')
+  .option('--base-dir <dir>', BASE_DIR_OPTION_DESCRIPTION)
   .action(async (options) => {
     const isGlobal = options.global || false;
+    const baseDir = resolveBaseDirOrExit(options.baseDir, { global: isGlobal });
 
     if (!isGlobal) {
-      const configLoader = new ConfigLoader();
+      const configLoader = new ConfigLoader(baseDir);
 
       if (!configLoader.exists()) {
         logger.error("skills.json not found. Run 'reskill init' first.");
@@ -30,7 +33,7 @@ export const outdatedCommand = new Command('outdated')
       }
     }
 
-    const skillManager = new SkillManager(undefined, { global: isGlobal });
+    const skillManager = new SkillManager(baseDir, { global: isGlobal });
     const spinner = ora('Checking for updates...').start();
 
     try {

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -5,6 +5,7 @@ import { type AgentType, agents } from '../../core/agent-registry.js';
 import { ConfigLoader } from '../../core/config-loader.js';
 import { Installer } from '../../core/installer.js';
 import { SkillManager } from '../../core/skill-manager.js';
+import { BASE_DIR_OPTION_DESCRIPTION, resolveBaseDirOrExit } from '../../utils/base-dir.js';
 
 /**
  * uninstall command - Uninstall one or more skills
@@ -17,20 +18,23 @@ export const uninstallCommand = new Command('uninstall')
   .argument('<skills...>', 'Skill names to uninstall')
   .option('-g, --global', 'Uninstall from global installation (~/.claude/skills)')
   .option('-y, --yes', 'Skip confirmation prompts')
+  .option('--base-dir <dir>', BASE_DIR_OPTION_DESCRIPTION)
   .action(async (skillNames: string[], options) => {
     const isGlobal = options.global || false;
     const skipConfirm = options.yes || false;
-    const skillManager = new SkillManager(undefined, { global: isGlobal });
+    const baseDir = resolveBaseDirOrExit(options.baseDir, { global: isGlobal });
+    const projectRoot = baseDir ?? process.cwd();
+    const skillManager = new SkillManager(baseDir, { global: isGlobal });
 
     console.log();
     p.intro(chalk.bgCyan.black(' reskill '));
 
     // Check which agents have these skills installed
     // Use installDir from config to match where skills are actually installed
-    const config = new ConfigLoader(process.cwd());
+    const config = new ConfigLoader(projectRoot);
     const defaults = config.getDefaults();
     const installer = new Installer({
-      cwd: process.cwd(),
+      cwd: projectRoot,
       global: isGlobal,
       installDir: defaults.installDir,
     });

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import ora from 'ora';
 import { ConfigLoader } from '../../core/config-loader.js';
 import { SkillManager } from '../../core/skill-manager.js';
+import { BASE_DIR_OPTION_DESCRIPTION, resolveBaseDirOrExit } from '../../utils/base-dir.js';
 import { logger } from '../../utils/logger.js';
 
 /**
@@ -12,11 +13,13 @@ export const updateCommand = new Command('update')
   .description('Update installed skills')
   .argument('[skill]', 'Skill name to update (updates all if not specified)')
   .option('-g, --global', 'Update globally installed skills')
+  .option('--base-dir <dir>', BASE_DIR_OPTION_DESCRIPTION)
   .action(async (skill, options) => {
     const isGlobal = options.global || false;
+    const baseDir = resolveBaseDirOrExit(options.baseDir, { global: isGlobal });
 
     if (!isGlobal) {
-      const configLoader = new ConfigLoader();
+      const configLoader = new ConfigLoader(baseDir);
 
       if (!configLoader.exists()) {
         logger.error("skills.json not found. Run 'reskill init' first.");
@@ -24,7 +27,7 @@ export const updateCommand = new Command('update')
       }
     }
 
-    const skillManager = new SkillManager(undefined, { global: isGlobal });
+    const skillManager = new SkillManager(baseDir, { global: isGlobal });
     const spinner = ora(skill ? `Updating ${skill}...` : 'Updating all skills...').start();
 
     try {

--- a/src/utils/base-dir.test.ts
+++ b/src/utils/base-dir.test.ts
@@ -1,0 +1,109 @@
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveBaseDir } from './base-dir.js';
+import { remove } from './fs.js';
+
+describe('resolveBaseDir', () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    // macOS reports /var as a symlink to /private/var, so realpath-normalize
+    // the temp root to keep absolute-path assertions exact.
+    tempDir = realpathSync(mkdtempSync(path.join(tmpdir(), 'reskill-base-dir-')));
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    remove(tempDir);
+  });
+
+  describe('when the option is not supplied', () => {
+    it('returns undefined so callers keep process.cwd() behavior', () => {
+      expect(resolveBaseDir(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined even when --global is set', () => {
+      expect(resolveBaseDir(undefined, { global: true })).toBeUndefined();
+    });
+  });
+
+  describe('resolving valid directories', () => {
+    it('returns an existing absolute path unchanged', () => {
+      expect(resolveBaseDir(tempDir)).toBe(path.resolve(tempDir));
+    });
+
+    it('resolves a relative path against the current working directory', () => {
+      process.chdir(tempDir);
+      const agentDir = path.join(tempDir, 'agents', 'foo');
+      mkdirSync(agentDir, { recursive: true });
+
+      expect(resolveBaseDir('agents/foo')).toBe(path.resolve(tempDir, 'agents/foo'));
+    });
+
+    it('trims surrounding whitespace before resolving', () => {
+      expect(resolveBaseDir(`  ${tempDir}  `)).toBe(path.resolve(tempDir));
+    });
+
+    it('normalizes traversal segments in the supplied path', () => {
+      const nested = path.join(tempDir, 'agents');
+      mkdirSync(nested, { recursive: true });
+
+      expect(resolveBaseDir(path.join(nested, '..'))).toBe(path.resolve(tempDir));
+    });
+  });
+
+  describe('rejecting invalid values', () => {
+    it('throws when the directory does not exist', () => {
+      const missing = path.join(tempDir, 'no-such-agent');
+
+      expect(() => resolveBaseDir(missing)).toThrow(/--base-dir directory not found/);
+    });
+
+    it('names the resolved absolute path in the not-found error', () => {
+      const missing = path.join(tempDir, 'no-such-agent');
+
+      expect(() => resolveBaseDir(missing)).toThrow(missing);
+    });
+
+    it('throws when the path points to a file instead of a directory', () => {
+      const filePath = path.join(tempDir, 'skills.json');
+      writeFileSync(filePath, '{}');
+
+      expect(() => resolveBaseDir(filePath)).toThrow(/--base-dir must point to a directory/);
+    });
+
+    it('throws on an empty string', () => {
+      expect(() => resolveBaseDir('')).toThrow(/requires a non-empty directory path/);
+    });
+
+    it('throws on a whitespace-only string', () => {
+      expect(() => resolveBaseDir('   ')).toThrow(/requires a non-empty directory path/);
+    });
+  });
+
+  describe('conflict with --global', () => {
+    it('throws when combined with --global', () => {
+      expect(() => resolveBaseDir(tempDir, { global: true })).toThrow(
+        /--base-dir cannot be combined with --global/,
+      );
+    });
+
+    it('rejects the combination before validating the directory exists', () => {
+      const missing = path.join(tempDir, 'no-such-agent');
+
+      // The global conflict is a usage error, so it must win over path checks
+      // to avoid a confusing "not found" message for an unsupported flag combo.
+      expect(() => resolveBaseDir(missing, { global: true })).toThrow(
+        /cannot be combined with --global/,
+      );
+    });
+
+    it('resolves normally when global is explicitly false', () => {
+      expect(resolveBaseDir(tempDir, { global: false })).toBe(path.resolve(tempDir));
+    });
+  });
+});

--- a/src/utils/base-dir.ts
+++ b/src/utils/base-dir.ts
@@ -1,0 +1,86 @@
+/**
+ * Base directory resolution for the --base-dir option
+ *
+ * `--base-dir` overrides the root that project-level operations resolve
+ * against. skills.json, skills.lock, and every agent's skills directory all
+ * derive from the same project root, so a single flag relocates a complete
+ * skill set into an arbitrary directory.
+ *
+ * This enables per-instance isolation: a host that manages several agent
+ * definitions side by side can give each one its own directory and install
+ * into them independently.
+ */
+
+import path from 'node:path';
+import { exists, isDirectory } from './fs.js';
+import { logger } from './logger.js';
+
+/**
+ * Resolve a --base-dir value into an absolute directory path.
+ *
+ * Returns undefined when the option was not supplied, letting callers keep
+ * their existing process.cwd() behavior.
+ *
+ * The directory must already exist. Creating it on demand would turn a typo
+ * into an empty skill set that only fails much later, far away from the
+ * mistake that caused it.
+ *
+ * @param baseDir Raw option value, or undefined when not supplied
+ * @param options.global Whether the command also received --global
+ * @throws When the value is empty, missing, not a directory, or combined
+ *   with --global
+ */
+export function resolveBaseDir(
+  baseDir: string | undefined,
+  options: { global?: boolean } = {},
+): string | undefined {
+  if (baseDir === undefined) {
+    return undefined;
+  }
+
+  if (options.global) {
+    throw new Error(
+      '--base-dir cannot be combined with --global: global installs always resolve to the user home directory',
+    );
+  }
+
+  const trimmed = baseDir.trim();
+  if (trimmed === '') {
+    throw new Error('--base-dir requires a non-empty directory path');
+  }
+
+  const resolved = path.resolve(process.cwd(), trimmed);
+
+  if (!exists(resolved)) {
+    throw new Error(`--base-dir directory not found: ${resolved}`);
+  }
+
+  if (!isDirectory(resolved)) {
+    throw new Error(`--base-dir must point to a directory: ${resolved}`);
+  }
+
+  return resolved;
+}
+
+/**
+ * Resolve --base-dir, reporting failures as a CLI error instead of throwing.
+ *
+ * For commands whose action has no surrounding error handling, an uncaught
+ * throw would surface as a stack trace. This keeps the failure consistent
+ * with how those commands report every other usage error.
+ */
+export function resolveBaseDirOrExit(
+  baseDir: string | undefined,
+  options: { global?: boolean } = {},
+): string | undefined {
+  try {
+    return resolveBaseDir(baseDir, options);
+  } catch (error) {
+    logger.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+/** Shared description for the --base-dir option across commands */
+export const BASE_DIR_OPTION_DESCRIPTION =
+  'Project root to resolve skills.json, skills.lock and agent skill directories against (default: current directory)';

--- a/src/utils/base-dir.windows.test.ts
+++ b/src/utils/base-dir.windows.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Windows-specific --base-dir Resolution Tests
+ *
+ * These tests simulate Windows path semantics by mocking `node:path` with its
+ * `win32` implementation. Contributors and CI run on macOS/Linux, where a
+ * backslash is an ordinary filename character, so Windows separator handling
+ * would otherwise never be exercised.
+ *
+ * The filesystem checks are stubbed out: this file is about how a supplied
+ * path is normalized, not about what exists on disk.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:path', async () => {
+  const actual = await vi.importActual<typeof import('node:path')>('node:path');
+  return { ...actual.win32, default: actual.win32 };
+});
+
+vi.mock('./fs.js', () => ({
+  exists: vi.fn(() => true),
+  isDirectory: vi.fn(() => true),
+}));
+
+const { resolveBaseDir } = await import('./base-dir.js');
+
+describe('resolveBaseDir (Windows path semantics)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('absolute paths', () => {
+    it('returns a drive-letter path unchanged', () => {
+      expect(resolveBaseDir('C:\\agents\\foo')).toBe('C:\\agents\\foo');
+    });
+
+    it('normalizes a trailing separator away', () => {
+      expect(resolveBaseDir('C:\\agents\\foo\\')).toBe('C:\\agents\\foo');
+    });
+
+    it('normalizes traversal segments', () => {
+      expect(resolveBaseDir('C:\\agents\\foo\\..\\bar')).toBe('C:\\agents\\bar');
+    });
+  });
+
+  describe('relative paths', () => {
+    it('treats a backslash as a separator, not a filename character', () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('C:\\workspace');
+
+      // On POSIX this would resolve to a single literal "agents\foo" segment;
+      // on Windows it must nest into agents\foo.
+      expect(resolveBaseDir('agents\\foo')).toBe('C:\\workspace\\agents\\foo');
+    });
+
+    it('also accepts forward slashes, which Windows allows', () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('C:\\workspace');
+
+      expect(resolveBaseDir('agents/foo')).toBe('C:\\workspace\\agents\\foo');
+    });
+
+    it('resolves against the drive root when cwd is a drive root', () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('D:\\');
+
+      expect(resolveBaseDir('agents\\bar')).toBe('D:\\agents\\bar');
+    });
+  });
+
+  describe('validation still applies', () => {
+    it('rejects an empty value before touching the filesystem', () => {
+      expect(() => resolveBaseDir('   ')).toThrow(/requires a non-empty directory path/);
+    });
+
+    it('rejects the --global combination', () => {
+      expect(() => resolveBaseDir('C:\\agents\\foo', { global: true })).toThrow(
+        /cannot be combined with --global/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #353

## What

Adds `--base-dir <dir>` to `install`, `list`, `update`, `outdated` and `uninstall`. It overrides the project root that project-level operations resolve against — `skills.json`, `skills.lock` and every target agent's skills directory move together.

```bash
reskill install github:user/skill --base-dir agents/foo -a claude-code cursor
```

```
agents/foo/skills.json          # read + written here
agents/foo/skills.lock
agents/foo/.claude/skills/      # each agent keeps its own layout
agents/foo/.cursor/skills/
```

## Why

Enables per-instance isolation: several agent definitions can live side by side under one parent directory, each with an independent skill set. Previously the only choices were the current directory (project-level) or the user home directory (`-g`), and neither could express "this agent's own skill set" — `-g` made siblings overwrite each other, and project-level tied the skill set to whatever directory the runtime happened to run from.

Note the two "agent" senses are orthogonal here: the isolation dimension is the *instance* (the base dir), while `-a` still selects which *coding agents* (claude-code, cursor, …) get the skill. `--base-dir` parameterizes the former and leaves the latter's default layout intact, so all 18 agents are covered.

## Implementation

`SkillManager`, `ConfigLoader` and `getAgentSkillsDir` already accepted a project root — the CLI passed `undefined` at all 4 call sites and never exposed it. This wires it through. **No path-resolution logic changed**, so behavior without the flag is identical.

Validation in `src/utils/base-dir.ts`:
- Directory must already exist — creating it on demand would turn a typo into an empty skill set that only fails much later
- Must be a directory, not a file
- Cannot combine with `-g/--global`, which always resolves to the user home directory
- All failures exit 1

## Testing

- **Unit** (`base-dir.test.ts`, 14): path resolution, trimming, traversal normalization, each rejection path, `--global` conflict precedence
- **Windows** (`base-dir.windows.test.ts`, 8): mocks `node:path` → `win32` (same pattern as `extractor.windows.test.ts`) to verify backslashes are treated as separators rather than filename characters
- **Integration** (`install-base-dir.test.ts`, 23): real installs from a local git repo — layout under the base dir, cwd left untouched, manifest/lock placement, multi-agent layout, isolation between siblings, `list` read-back, and exit codes for every rejection across all 5 commands

Full suite: 42 unit files / 1576 passed, 17 integration files / 276 passed. Typecheck and lint clean.

## Out of scope

- **`-g/--global`** — global paths still resolve to `homedir()`, which is fixed at module load in `agent-registry.ts`. Supporting a relocatable global root needs lazy evaluation; if that pain point is real it should be its own issue.
- **Cache concurrency** — `CacheManager.cache()` uses a deterministic `${cachePath}.tmp`, unconditionally removes it before cloning, and copies rather than atomically renaming, with no lock. Two processes installing the same skill version concurrently can interfere. Pre-existing and unrelated to this change, but it means multiple base dirs should be installed **sequentially**; documented in the README. Worth a separate issue.
- **`--ci` structured output** (the secondary ask in #353) — orthogonal to paths, better as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
