### PR TITLE
ci: fix npm auto-release via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # v6 or newer is required to install the pnpm 11 pinned in packageManager.
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
+      # '22.x' resolves to the newest 22.x, which satisfies the Node >= 22.13
+      # that pnpm 11 requires. Do not pin below that.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,12 +23,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      # v6 or newer is required: earlier versions bootstrap with a pnpm 8 that
+      # cannot install the pnpm 11 pinned in packageManager (it unpacks the
+      # tarball but leaves node_modules/.bin/pnpm dangling).
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       # No registry-url: it would make setup-node write an .npmrc with
       # `_authToken=${NODE_AUTH_TOKEN}`, and a static token takes us off the
       # trusted publishing path. Auth comes from OIDC (see permissions above).
+      # '22.x' also keeps us above the Node >= 22.13 that pnpm 11 requires.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -69,7 +73,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       # See the note in the release job: no registry-url, auth comes from OIDC.
       - name: Setup Node.js

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,9 @@ jobs:
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
+          # pnpm 11 reads its own settings from pnpm_config_* only; the npm_config_*
+          # form is ignored, which would leave provenance up to auto-detection.
+          pnpm_config_provenance: true
 
   beta-release:
     name: Beta Release
@@ -128,7 +130,8 @@ jobs:
         if: steps.check-pre.outputs.is_pre == 'true' && steps.check-version.outputs.has_changes == 'true'
         run: pnpm changeset publish
         env:
-          NPM_CONFIG_PROVENANCE: true
+          # See the note in the release job on the pnpm_config_ prefix.
+          pnpm_config_provenance: true
 
       - name: Commit version bump back to branch
         if: steps.check-pre.outputs.is_pre == 'true' && steps.check-version.outputs.has_changes == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,11 +26,13 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
+      # No registry-url: it would make setup-node write an .npmrc with
+      # `_authToken=${NODE_AUTH_TOKEN}`, and a static token takes us off the
+      # trusted publishing path. Auth comes from OIDC (see permissions above).
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -49,7 +51,6 @@ jobs:
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
   beta-release:
@@ -68,11 +69,11 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
+      # See the note in the release job: no registry-url, auth comes from OIDC.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -127,7 +128,6 @@ jobs:
         if: steps.check-pre.outputs.is_pre == 'true' && steps.check-version.outputs.has_changes == 'true'
         run: pnpm changeset publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Commit version bump back to branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,11 @@ reskill is a Git-based package manager for AI agent skills, similar to npm/Go mo
 ## Tech Stack
 
 - **Language:** TypeScript (ES Modules)
-- **Runtime:** Node.js >= 18.0.0
+- **Runtime:** Node.js >= 18.0.0 (published package); Node.js >= 22.13 to develop, since pnpm 11 requires it
 - **Build Tool:** Rslib (Rspack-based library bundler)
+- **Package Manager:** pnpm 11 (pinned via `packageManager`; settings live in `pnpm-workspace.yaml`, not the `pnpm` field)
 - **Testing:** Vitest with @vitest/coverage-v8
 - **CLI Framework:** Commander.js
-- **Package Manager:** pnpm
 
 ## Development Commands
 
@@ -257,6 +257,20 @@ When creating or modifying CLI commands:
 ```bash
 pnpm test:run && pnpm test:integration && pnpm typecheck && pnpm lint
 ```
+
+## Releasing
+
+`.github/workflows/publish.yml` publishes to npm through **trusted publishing (OIDC)**, not a
+static token. `pnpm publish` exchanges the workflow's OIDC id-token for a short-lived registry
+token by itself, so:
+
+- Do not add `registry-url` to `setup-node`. It writes an `.npmrc` with
+  `_authToken=${NODE_AUTH_TOKEN}`, and a static token takes precedence over the OIDC path.
+- Keep `permissions.id-token: write` on any job that publishes.
+- Provenance is set via `pnpm_config_provenance`. pnpm ignores the `npm_config_*` prefix.
+- The trust relationship is configured on npmjs.com (package → Settings → Trusted Publisher) and
+  is pinned to this repository plus the `publish.yml` workflow filename. Renaming the workflow
+  file breaks publishing until the npm setting is updated to match.
 
 ## Git Commits
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.25.0",
   "description": "AI Skills Package Manager - Git-based skills management for AI agents",
   "type": "module",
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@11.21.0",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  # Only prints a sponsorship banner; nothing to build.
+  core-js: false
+  # Links the platform-specific binary used by rslib/vitest.
+  esbuild: true


### PR DESCRIPTION
## Summary

Auto-release has been silently broken since 1.23.0: every publish since then hit npm E403 in CI and was rescued by a manual `npm publish` minutes later. Nobody rescued 1.25.0 — npm's `latest` is still 1.24.1 while `main` is at 1.25.0.

Root cause: the release job's env sets `NODE_AUTH_TOKEN` (for `actions/setup-node`'s `.npmrc`) but never an env var named `NPM_TOKEN`. `changesets/action@v1` only writes registry auth when `NPM_TOKEN` is present — otherwise it just logs "using npm trusted publishing" and performs **no token exchange**, deferring entirely to `pnpm publish`. And `packageManager` was pinned to `pnpm@9.15.0`, which has zero OIDC support. So auth silently fell back to the dead static token in `.npmrc` → E403.

The package already has an npm Trusted Publisher configured (kanyun-inc/reskill + publish.yml). This PR makes that actually work instead of rotating the token again.

## Changes

- `packageManager`: pnpm 9.15.0 → 11.21.0 (pnpm 11 performs the OIDC exchange itself)
- `pnpm/action-setup@v4` → `@v6` in both workflows — v4's bootstrap (pnpm 8.14.3) cannot install pnpm 11 at all (leaves `node_modules/.bin/pnpm` dangling); v6 bootstraps via pnpm 11.19.0 + self-update
- New `pnpm-workspace.yaml` with `allowBuilds` — pnpm 11 requires explicit build-script approval and no longer reads the `pnpm` field in `package.json`
- `publish.yml`: drop `registry-url` and `NODE_AUTH_TOKEN` from both jobs (a static token would short-circuit the OIDC path)
- `NPM_CONFIG_PROVENANCE` → `pnpm_config_provenance` (pnpm 11 only honors the `pnpm_config_*` env prefix)
- `CLAUDE.md`: documents the OIDC constraints for future changes to this workflow

## Testing

Locally on pnpm 11.21.0 / Node 22.22.1:
- `pnpm install --frozen-lockfile` — lockfile byte-identical after
- typecheck, 1576 unit tests (42 files), build, 276 integration tests (17 files) — all pass
- `pnpm publish --dry-run --no-git-checks` — packs correctly, valid `--json` output
- `pnpm pack` manifest has `packageManager` stripped (matches published 1.24.1)
- Simulated the linux-x64 CI runner locally via a temporary `supportedArchitectures` override: `--frozen-lockfile` installs the linux binaries cleanly, lockfile unchanged
- Scanned all 350 lockfile packages against the npm registry for install scripts: only `core-js`/`esbuild` (declared in `allowBuilds`) and `fsevents` (darwin-only, never resolves in CI)
- Verified pnpm 11's OIDC path is unconditional and overrides any static token, the default registry resolves to registry.npmjs.org with no `.npmrc` present, and `minimumReleaseAge` (a pnpm 11 default some worried could gate freshly-published deps) has no effect here — empirically confirmed by installing a real npm package version published 3.5h earlier with no age-related failure

`pnpm lint` is red on `main` already (pre-existing biome findings in test files, unrelated to this change) and CI doesn't run lint, so left untouched.

## Rollback

If CI still fails to publish after this merges, falling back to a manual `npm publish` is unaffected by this change — nothing here removes that escape hatch.
