### PR TITLE
feat: support custom agent targets beyond the built-in list

### DIFF
--- a/.changeset/custom-agent-targets.md
+++ b/.changeset/custom-agent-targets.md
@@ -1,0 +1,21 @@
+---
+"reskill": minor
+---
+
+feat: support custom agent targets beyond the built-in list
+
+- Skills can now be installed into directories that are not part of the built-in agent table. Declare an alias → directory under a new `customAgents` field in `skills.json` (e.g. `"cc-switch": { "path": ".cc-switch/skills", "globalPath": "~/.cc-switch/skills" }`), then use that alias anywhere a built-in agent name is accepted — `-a`, `defaults.targetAgents`, `list -a`, and `uninstall`
+- The `-a` flag now accepts an `alias:path` form (e.g. `-a cc-switch:.cc-switch/skills`) that installs into an arbitrary directory. On a successful project install the alias is persisted into `skills.json` under `customAgents`, so later commands reuse it without repeating the path
+- `path` is a project-relative directory (required). `globalPath` is an absolute directory (a leading `~` expands to the home directory) used for `-g/--global` installs; a global install into a custom agent without `globalPath` is rejected with a clear error
+- `doctor` now validates `customAgents` entries (non-empty, relative `path`) and no longer flags custom aliases in `targetAgents` as unknown agents
+- The built-in `AgentType` union is widened to also accept arbitrary alias strings; built-in agent behavior is unchanged
+
+---
+
+feat: 支持内置列表之外的自定义 Agent 目标
+
+- 现在可以把 skill 安装到不在内置 Agent 列表里的目录。在 `skills.json` 新增的 `customAgents` 字段里声明「别名 → 目录」（例如 `"cc-switch": { "path": ".cc-switch/skills", "globalPath": "~/.cc-switch/skills" }`），随后即可在任何接受内置 Agent 名的地方使用该别名——`-a`、`defaults.targetAgents`、`list -a` 以及 `uninstall`
+- `-a` 现在支持 `别名:路径` 写法（例如 `-a cc-switch:.cc-switch/skills`），可安装到任意目录。项目级安装成功后，该别名会被写回 `skills.json` 的 `customAgents`，后续命令无需再重复路径即可复用
+- `path` 是相对于项目根的目录（必填）。`globalPath` 是绝对目录（开头的 `~` 会展开为家目录），用于 `-g/--global` 安装；对未配置 `globalPath` 的自定义 Agent 执行全局安装会以清晰的错误被拒绝
+- `doctor` 现在会校验 `customAgents` 条目（`path` 非空且为相对路径），并且不再把 `targetAgents` 中的自定义别名判定为未知 Agent
+- 内置的 `AgentType` 联合类型放宽为同时接受任意别名字符串；内置 Agent 的行为保持不变

--- a/README.md
+++ b/README.md
@@ -250,6 +250,40 @@ Skills are installed to `.skills/` by default and can be integrated with any age
 | Trae           | `.trae/skills`     |
 | Windsurf       | `.windsurf/skills` |
 
+### Custom Agent Targets
+
+Not every tool is in the built-in table. Declare your own alias → directory
+under `customAgents` in `skills.json`, then use it anywhere a built-in agent
+name is accepted (`-a`, `defaults.targetAgents`, `list -a`, `uninstall`):
+
+```json
+{
+  "skills": {},
+  "defaults": { "targetAgents": ["claude-code", "cc-switch"] },
+  "customAgents": {
+    "cc-switch": {
+      "path": ".cc-switch/skills",
+      "globalPath": "~/.cc-switch/skills"
+    }
+  }
+}
+```
+
+- `path` — project-level directory, relative to the project root (required).
+- `globalPath` — absolute directory (a leading `~` expands to your home) used
+  for `-g/--global` installs. Global installs into a custom agent without a
+  `globalPath` are rejected.
+
+You can also declare a custom agent inline with `alias:path` on the CLI. On a
+successful project install the alias is written back into `skills.json` under
+`customAgents`, so subsequent commands (`reskill install`, `list -a`, …) reuse
+it without repeating the path:
+
+```bash
+reskill install github:user/skill -a cc-switch:.cc-switch/skills
+# → skills.json now contains customAgents["cc-switch"] = { "path": ".cc-switch/skills" }
+```
+
 ### Isolated Project Roots
 
 By default, project-level commands resolve everything against the current

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -250,6 +250,38 @@ Skills 默认安装到 `.skills/`，可与任何 Agent 集成：
 | Trae           | `.trae/skills`     |
 | Windsurf       | `.windsurf/skills` |
 
+### 自定义 Agent 目标
+
+内置列表之外的工具，可以在 `skills.json` 的 `customAgents` 里声明「别名 → 目录」，
+然后在任何接受内置 Agent 名的地方使用它（`-a`、`defaults.targetAgents`、
+`list -a`、`uninstall`）：
+
+```json
+{
+  "skills": {},
+  "defaults": { "targetAgents": ["claude-code", "cc-switch"] },
+  "customAgents": {
+    "cc-switch": {
+      "path": ".cc-switch/skills",
+      "globalPath": "~/.cc-switch/skills"
+    }
+  }
+}
+```
+
+- `path` — 项目级目录，相对于项目根（必填）。
+- `globalPath` — 绝对目录（开头的 `~` 会展开为家目录），用于 `-g/--global` 安装。
+  对未配置 `globalPath` 的自定义 Agent 执行全局安装会被拒绝。
+
+也可以直接在 CLI 用 `别名:路径` 声明自定义 Agent。项目级安装成功后，该别名会被
+写回 `skills.json` 的 `customAgents`，后续命令（`reskill install`、`list -a` 等）
+无需再重复路径即可复用：
+
+```bash
+reskill install github:user/skill -a cc-switch:.cc-switch/skills
+# → skills.json 中会写入 customAgents["cc-switch"] = { "path": ".cc-switch/skills" }
+```
+
 ### 隔离的项目根目录
 
 默认情况下，项目级命令都基于当前目录解析路径。`--base-dir` 可以把它们指向另一个项目根目录——`skills.json`、`skills.lock` 和各 Agent 目录会一起迁移：

--- a/src/cli/commands/__integration__/install-custom-agents.test.ts
+++ b/src/cli/commands/__integration__/install-custom-agents.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Integration tests for custom agent targets (issue #381)
+ *
+ * Custom agents let users install skills into directories that are not part of
+ * the built-in agent table, either declared in skills.json under `customAgents`
+ * or passed ad-hoc on the CLI as `-a alias:path`.
+ *
+ * Layout under test:
+ *
+ *   <temp>/.cc-switch/skills/<skill>       (custom agent target)
+ *   <temp>/skills.json                     (declares customAgents)
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createLocalGitRepo,
+  createTempDir,
+  getOutput,
+  pathExists,
+  removeTempDir,
+  runCli,
+} from './helpers.js';
+
+describe('CLI Integration: install custom agents', () => {
+  let tempDir: string;
+  let repoUrl: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    repoUrl = createLocalGitRepo(tempDir, 'demo-skill');
+  });
+
+  afterEach(() => {
+    removeTempDir(tempDir);
+  });
+
+  describe('customAgents declared in skills.json', () => {
+    function writeCustomConfig(): void {
+      const config = {
+        skills: {},
+        defaults: { installDir: '.skills', targetAgents: ['cc-switch'] },
+        customAgents: {
+          'cc-switch': { path: '.cc-switch/skills' },
+        },
+      };
+      fs.writeFileSync(path.join(tempDir, 'skills.json'), JSON.stringify(config, null, 2));
+    }
+
+    it('should install into the custom agent directory', () => {
+      writeCustomConfig();
+
+      const { exitCode } = runCli(`install ${repoUrl}@v1.0.0 -a cc-switch -y`, tempDir);
+
+      expect(exitCode).toBe(0);
+      expect(pathExists(path.join(tempDir, '.cc-switch/skills/demo-skill'))).toBe(true);
+    });
+
+    it('should list skills installed to the custom agent', () => {
+      writeCustomConfig();
+      runCli(`install ${repoUrl}@v1.0.0 -a cc-switch -y`, tempDir);
+
+      const result = runCli('list -a cc-switch', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(getOutput(result)).toContain('demo-skill');
+    });
+
+    it('should uninstall from the custom agent', () => {
+      writeCustomConfig();
+      runCli(`install ${repoUrl}@v1.0.0 -a cc-switch -y`, tempDir);
+      expect(pathExists(path.join(tempDir, '.cc-switch/skills/demo-skill'))).toBe(true);
+
+      const result = runCli('uninstall demo-skill -y', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(pathExists(path.join(tempDir, '.cc-switch/skills/demo-skill'))).toBe(false);
+    });
+  });
+
+  describe('CLI alias:path syntax (no config)', () => {
+    it('should install into an ad-hoc custom directory', () => {
+      const { exitCode } = runCli(
+        `install ${repoUrl}@v1.0.0 -a cc-switch:.cc-switch/skills -y`,
+        tempDir,
+      );
+
+      expect(exitCode).toBe(0);
+      expect(pathExists(path.join(tempDir, '.cc-switch/skills/demo-skill'))).toBe(true);
+    });
+
+    it('should persist the alias into skills.json customAgents', () => {
+      runCli(`install ${repoUrl}@v1.0.0 -a cc-switch:.cc-switch/skills -y`, tempDir);
+
+      const config = JSON.parse(fs.readFileSync(path.join(tempDir, 'skills.json'), 'utf-8'));
+      expect(config.customAgents['cc-switch']).toEqual({ path: '.cc-switch/skills' });
+      expect(config.defaults.targetAgents).toContain('cc-switch');
+    });
+
+    it('should let a later reinstall reuse the persisted custom agent', () => {
+      // First install persists the alias via alias:path
+      runCli(`install ${repoUrl}@v1.0.0 -a cc-switch:.cc-switch/skills -y`, tempDir);
+      // Remove the installed tree, then reinstall-all with no -a: must reuse config
+      fs.rmSync(path.join(tempDir, '.cc-switch'), { recursive: true, force: true });
+
+      const result = runCli('install -y', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(pathExists(path.join(tempDir, '.cc-switch/skills/demo-skill'))).toBe(true);
+    });
+
+    it('should reject an alias:path with an empty path', () => {
+      const result = runCli(`install ${repoUrl}@v1.0.0 -a cc-switch: -y`, tempDir);
+      expect(result.exitCode).toBe(1);
+      expect(getOutput(result)).toContain('missing path');
+    });
+  });
+
+  describe('built-in agents unaffected', () => {
+    it('should still install to a built-in agent', () => {
+      const { exitCode } = runCli(`install ${repoUrl}@v1.0.0 -a claude-code -y`, tempDir);
+      expect(exitCode).toBe(0);
+      expect(pathExists(path.join(tempDir, '.claude/skills/demo-skill'))).toBe(true);
+    });
+
+    it('should still reject an unknown agent name', () => {
+      const result = runCli(`install ${repoUrl}@v1.0.0 -a not-a-real-agent -y`, tempDir);
+      expect(result.exitCode).toBe(1);
+      expect(getOutput(result)).toContain('Invalid agents');
+    });
+  });
+});

--- a/src/cli/commands/completion.test.ts
+++ b/src/cli/commands/completion.test.ts
@@ -38,20 +38,13 @@ vi.mock('../../core/skill-manager.js', () => ({
 }));
 
 vi.mock('../../core/agent-registry.js', () => ({
-  agents: {
-    cursor: {
-      name: 'cursor',
-      displayName: 'Cursor',
-    },
-    'claude-code': {
-      name: 'claude-code',
-      displayName: 'Claude Code',
-    },
-    windsurf: {
-      name: 'windsurf',
-      displayName: 'Windsurf',
-    },
-  },
+  getAllAgentTypes: () => ['cursor', 'claude-code', 'windsurf'],
+}));
+
+vi.mock('../../core/config-loader.js', () => ({
+  ConfigLoader: vi.fn().mockImplementation(() => ({
+    getCustomAgents: () => ({}),
+  })),
 }));
 
 // ============================================================================

--- a/src/cli/commands/completion.ts
+++ b/src/cli/commands/completion.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import tabtab from 'tabtab';
-import { type AgentType, agents } from '../../core/agent-registry.js';
+import { getAllAgentTypes } from '../../core/agent-registry.js';
+import { ConfigLoader } from '../../core/config-loader.js';
 import { SkillManager } from '../../core/skill-manager.js';
 import { logger } from '../../utils/logger.js';
 
@@ -27,7 +28,11 @@ const SKILL_COMPLETION_COMMANDS = ['info', 'uninstall', 'update'];
  * Get all agent type names for completion
  */
 function getAgentNames(): string[] {
-  return Object.keys(agents) as AgentType[];
+  try {
+    return getAllAgentTypes(new ConfigLoader().getCustomAgents());
+  } catch {
+    return getAllAgentTypes();
+  }
 }
 
 /**

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -610,15 +610,38 @@ export function checkTargetAgents(cwd: string): CheckResult[] {
 
   try {
     const defaults = configLoader.getDefaults();
+    const customAgents = configLoader.getCustomAgents();
     const targetAgents = defaults.targetAgents || [];
 
     for (const agent of targetAgents) {
-      if (!isValidAgentType(agent)) {
+      if (!isValidAgentType(agent, customAgents)) {
         results.push({
           name: 'Invalid agent',
           status: 'warn',
           message: `Unknown agent type: "${agent}"`,
-          hint: 'Run: reskill install --help to see valid agent types',
+          hint: 'Run: reskill install --help to see valid agent types, or declare a customAgents entry',
+        });
+      }
+    }
+
+    // Validate custom agent declarations themselves.
+    for (const [alias, cfg] of Object.entries(customAgents)) {
+      const relPath = cfg.path?.trim();
+      if (!relPath) {
+        results.push({
+          name: 'Invalid custom agent',
+          status: 'warn',
+          message: `Custom agent "${alias}" has an empty path`,
+          hint: 'Set customAgents.<alias>.path to a directory relative to the project root',
+        });
+        continue;
+      }
+      if (relPath.startsWith('/') || relPath.includes('..')) {
+        results.push({
+          name: 'Invalid custom agent',
+          status: 'warn',
+          message: `Custom agent "${alias}" path "${relPath}" must be a relative path without ".."`,
+          hint: 'Use a project-relative path; set globalPath for absolute global targets',
         });
       }
     }

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,7 +1,13 @@
 import * as p from '@clack/prompts';
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { type AgentType, agents, detectInstalledAgents } from '../../core/agent-registry.js';
+import {
+  type AgentType,
+  agents,
+  type CustomAgentMap,
+  detectInstalledAgents,
+  getAgentConfig,
+} from '../../core/agent-registry.js';
 import { AuthManager } from '../../core/auth-manager.js';
 import { CLAUDE_COWORK_3P_AGENT } from '../../core/claude-3p-installer.js';
 import { ConfigLoader } from '../../core/config-loader.js';
@@ -51,6 +57,10 @@ interface InstallContext {
   skipManifest: boolean;
   /** Resolved absolute project root, or undefined to use process.cwd() */
   baseDir: string | undefined;
+  /** Custom agents declared in skills.json (alias -> config) */
+  customAgents: CustomAgentMap;
+  /** Ephemeral custom agents parsed from CLI `-a alias:path` (not persisted) */
+  ephemeralCustomAgents: CustomAgentMap;
 }
 
 // ============================================================================
@@ -61,8 +71,16 @@ interface InstallContext {
  * Format agent names list for display
  * Truncates long lists with "+N more" suffix
  */
-function formatAgentNames(agentTypes: AgentType[], maxShow = 5): string {
-  const names = agentTypes.map((a) => agents[a].displayName);
+function agentDisplayName(agent: AgentType, custom?: CustomAgentMap): string {
+  try {
+    return getAgentConfig(agent, custom).displayName;
+  } catch {
+    return agent;
+  }
+}
+
+function formatAgentNames(agentTypes: AgentType[], maxShow = 5, custom?: CustomAgentMap): string {
+  const names = agentTypes.map((a) => agentDisplayName(a, custom));
   if (names.length <= maxShow) {
     return names.join(', ');
   }
@@ -74,8 +92,8 @@ function formatAgentNames(agentTypes: AgentType[], maxShow = 5): string {
 /**
  * Format agent names with chalk coloring
  */
-function formatColoredAgentNames(agentTypes: AgentType[]): string {
-  return agentTypes.map((a) => chalk.cyan(agents[a].displayName)).join(', ');
+function formatColoredAgentNames(agentTypes: AgentType[], custom?: CustomAgentMap): string {
+  return agentTypes.map((a) => chalk.cyan(agentDisplayName(a, custom))).join(', ');
 }
 
 /**
@@ -93,6 +111,46 @@ function filterValidAgents(
 }
 
 /**
+ * Parse CLI `-a` args, splitting off any `alias:path` custom-agent targets.
+ *
+ * A token is treated as a custom-agent declaration when it contains `:` and
+ * its alias part is not a built-in agent. The alias must not collide with a
+ * built-in agent name, and the path part must be non-empty.
+ */
+function parseCliCustomAgents(agentArgs: string[]): {
+  agentNames: string[];
+  ephemeral: CustomAgentMap;
+} {
+  const ephemeral: CustomAgentMap = {};
+  const agentNames: string[] = [];
+
+  for (const arg of agentArgs) {
+    const colon = arg.indexOf(':');
+    const alias = colon === -1 ? arg : arg.slice(0, colon);
+
+    // Built-in name (or bare name without ':') passes through unchanged.
+    if (colon === -1 || alias in agents) {
+      agentNames.push(arg);
+      continue;
+    }
+
+    const targetPath = arg.slice(colon + 1).trim();
+    if (alias === '') {
+      p.log.error(`Invalid custom agent target: "${arg}" (missing alias)`);
+      process.exit(1);
+    }
+    if (targetPath === '') {
+      p.log.error(`Invalid custom agent target: "${arg}" (missing path)`);
+      process.exit(1);
+    }
+    ephemeral[alias] = { path: targetPath };
+    agentNames.push(alias);
+  }
+
+  return { agentNames, ephemeral };
+}
+
+/**
  * Create install context from command arguments and options
  */
 function createInstallContext(skills: string[], options: InstallOptions): InstallContext {
@@ -100,8 +158,17 @@ function createInstallContext(skills: string[], options: InstallOptions): Instal
   // must be settled before the config loader looks for one.
   const baseDir = resolveBaseDir(options.baseDir, { global: options.global });
   const configLoader = new ConfigLoader(baseDir);
-  const allAgentTypes = Object.keys(agents) as AgentType[];
   const hasSkillsJson = configLoader.exists();
+
+  const customAgents = hasSkillsJson ? configLoader.getCustomAgents() : {};
+
+  // Parse any CLI `-a alias:path` targets before validation.
+  const { ephemeral: ephemeralCustomAgents } = options.agent
+    ? parseCliCustomAgents(options.agent)
+    : { ephemeral: {} as CustomAgentMap };
+
+  const combinedCustom = { ...customAgents, ...ephemeralCustomAgents };
+  const allAgentTypes = [...(Object.keys(agents) as AgentType[]), ...Object.keys(combinedCustom)];
 
   // Load stored defaults from skills.json
   const storedDefaults = hasSkillsJson ? configLoader.getDefaults() : null;
@@ -122,6 +189,8 @@ function createInstallContext(skills: string[], options: InstallOptions): Instal
     skipConfirm: options.yes ?? false,
     skipManifest: options.skipManifest ?? false,
     baseDir,
+    customAgents,
+    ephemeralCustomAgents,
   };
 }
 
@@ -144,14 +213,16 @@ async function resolveTargetAgents(
     return allAgentTypes;
   }
 
+  const combinedCustom = { ...ctx.customAgents, ...ctx.ephemeralCustomAgents };
+
   // Priority 2: -a/--agent flag
   if (options.agent && options.agent.length > 0) {
-    return resolveAgentsFromCLI(options.agent, allAgentTypes);
+    return resolveAgentsFromCLI(options.agent, allAgentTypes, combinedCustom);
   }
 
   // Priority 3: Reinstall all with stored agents
   if (isReinstallAll && hasStoredAgents && storedAgents) {
-    p.log.info(`Using saved agents: ${formatColoredAgentNames(storedAgents)}`);
+    p.log.info(`Using saved agents: ${formatColoredAgentNames(storedAgents, combinedCustom)}`);
     return storedAgents;
   }
 
@@ -162,8 +233,16 @@ async function resolveTargetAgents(
 /**
  * Resolve agents from CLI -a option
  */
-function resolveAgentsFromCLI(agentArgs: string[], validAgents: AgentType[]): AgentType[] {
-  const invalidAgents = agentArgs.filter((a) => !validAgents.includes(a as AgentType));
+function resolveAgentsFromCLI(
+  agentArgs: string[],
+  validAgents: AgentType[],
+  custom: CustomAgentMap,
+): AgentType[] {
+  // Re-parse to resolve `alias:path` tokens into bare aliases.
+  const { agentNames } = parseCliCustomAgents(agentArgs);
+
+  const validSet = new Set(validAgents);
+  const invalidAgents = agentNames.filter((a) => !validSet.has(a as AgentType));
 
   if (invalidAgents.length > 0) {
     p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
@@ -171,8 +250,8 @@ function resolveAgentsFromCLI(agentArgs: string[], validAgents: AgentType[]): Ag
     process.exit(1);
   }
 
-  const targetAgents = agentArgs as AgentType[];
-  p.log.info(`Installing to: ${formatAgentNames(targetAgents)}`);
+  const targetAgents = agentNames as AgentType[];
+  p.log.info(`Installing to: ${formatAgentNames(targetAgents, 5, custom)}`);
   return targetAgents;
 }
 
@@ -184,9 +263,10 @@ async function detectAndPromptAgents(
   spinner: ReturnType<typeof p.spinner>,
 ): Promise<AgentType[]> {
   const { allAgentTypes, storedAgents, hasStoredAgents, skipConfirm } = ctx;
+  const combinedCustom = { ...ctx.customAgents, ...ctx.ephemeralCustomAgents };
 
   spinner.start('Detecting installed agents...');
-  const installedAgents = await detectInstalledAgents();
+  const installedAgents = await detectInstalledAgents(combinedCustom);
   spinner.stop(
     `Detected ${chalk.green(installedAgents.length)} agent${installedAgents.length !== 1 ? 's' : ''}`,
   );
@@ -200,19 +280,21 @@ async function detectAndPromptAgents(
     return await promptAgentSelection(
       allAgentTypes,
       hasStoredAgents ? storedAgents : allAgentTypes,
+      false,
+      combinedCustom,
     );
   }
 
   // Single agent or skip confirmation
   if (installedAgents.length === 1 || skipConfirm) {
-    const displayNames = formatColoredAgentNames(installedAgents);
+    const displayNames = formatColoredAgentNames(installedAgents, combinedCustom);
     p.log.info(`Installing to: ${displayNames}`);
     return installedAgents;
   }
 
   // Multiple agents: let user select
   const initialAgents = hasStoredAgents ? storedAgents! : installedAgents;
-  return await promptAgentSelection(installedAgents, initialAgents, true);
+  return await promptAgentSelection(installedAgents, initialAgents, true, combinedCustom);
 }
 
 /**
@@ -222,16 +304,20 @@ async function promptAgentSelection(
   availableAgents: AgentType[],
   initialValues: AgentType[] | undefined,
   showHint = false,
+  custom?: CustomAgentMap,
 ): Promise<AgentType[]> {
   if (availableAgents.length === 0) {
     p.log.warn('No coding agents detected. You can still install skills.');
   }
 
-  const agentChoices = availableAgents.map((a) => ({
-    value: a,
-    label: agents[a].displayName,
-    ...(showHint && { hint: agents[a].skillsDir }),
-  }));
+  const agentChoices = availableAgents.map((a) => {
+    const config = getAgentConfig(a, custom);
+    return {
+      value: a,
+      label: config.displayName,
+      ...(showHint && { hint: config.skillsDir }),
+    };
+  });
 
   const selected = await p.multiselect({
     message: `Select agents to install skills to ${chalk.dim('(Space to toggle, Enter to confirm)')}`,
@@ -416,6 +502,7 @@ async function installAllSkills(
   const skillManager = new SkillManager(ctx.baseDir, {
     global: false,
     noManifest: ctx.skipManifest,
+    customAgents: ctx.ephemeralCustomAgents,
   });
   let totalInstalled = 0;
   let totalFailed = 0;
@@ -452,6 +539,7 @@ async function installAllSkills(
   // Save installation defaults
   if (totalInstalled > 0) {
     configLoader.updateDefaults({ targetAgents, installMode });
+    configLoader.updateCustomAgents(ctx.ephemeralCustomAgents);
   }
 }
 
@@ -472,6 +560,7 @@ async function installSingleSkill(
   const skillManager = new SkillManager(ctx.baseDir, {
     global: installGlobally,
     noManifest: ctx.skipManifest,
+    customAgents: ctx.ephemeralCustomAgents,
   });
 
   // Detect whether the ref points to a multi-skill directory
@@ -535,6 +624,7 @@ async function installSingleSkill(
   if (!installGlobally && successful.length > 0 && configLoader.exists()) {
     configLoader.reload(); // Sync with SkillManager's changes
     configLoader.updateDefaults({ targetAgents, installMode });
+    configLoader.updateCustomAgents(ctx.ephemeralCustomAgents);
   }
 }
 
@@ -618,6 +708,7 @@ async function installAutoDetectedMultiSkill(
   if (!installGlobally && installed.length > 0 && configLoader.exists()) {
     configLoader.reload();
     configLoader.updateDefaults({ targetAgents, installMode });
+    configLoader.updateCustomAgents(ctx.ephemeralCustomAgents);
   }
 }
 
@@ -637,6 +728,7 @@ async function installMultiSkillFromRepo(
   const skillManager = new SkillManager(ctx.baseDir, {
     global: installGlobally,
     noManifest: ctx.skipManifest,
+    customAgents: ctx.ephemeralCustomAgents,
   });
 
   if (listOnly) {
@@ -710,6 +802,7 @@ async function installMultiSkillFromRepo(
   if (!installGlobally && installed.length > 0 && ctx.configLoader.exists()) {
     ctx.configLoader.reload();
     ctx.configLoader.updateDefaults({ targetAgents, installMode });
+    ctx.configLoader.updateCustomAgents(ctx.ephemeralCustomAgents);
   }
 }
 
@@ -748,6 +841,7 @@ async function installMultipleSkills(
   const skillManager = new SkillManager(ctx.baseDir, {
     global: installGlobally,
     noManifest: ctx.skipManifest,
+    customAgents: ctx.ephemeralCustomAgents,
   });
   const successfulSkills: { name: string; version: string }[] = [];
   const failedSkills: { ref: string; error: string }[] = [];
@@ -804,6 +898,7 @@ async function installMultipleSkills(
   if (!installGlobally && successfulSkills.length > 0 && configLoader.exists()) {
     configLoader.reload(); // Sync with SkillManager's changes
     configLoader.updateDefaults({ targetAgents, installMode });
+    configLoader.updateCustomAgents(ctx.ephemeralCustomAgents);
   }
 
   // Exit with error if any skills failed
@@ -916,10 +1011,10 @@ function displaySingleSkillResults(
 
       const symlinked = successful
         .filter(([, r]) => !r.symlinkFailed)
-        .map(([a]) => agents[a].displayName);
+        .map(([a]) => agentDisplayName(a));
       const copied = successful
         .filter(([, r]) => r.symlinkFailed)
-        .map(([a]) => agents[a].displayName);
+        .map(([a]) => agentDisplayName(a));
 
       if (symlinked.length > 0) {
         resultLines.push(`  ${chalk.dim('symlink →')} ${symlinked.join(', ')}`);
@@ -939,7 +1034,7 @@ function displaySingleSkillResults(
     // Symlink failure warning
     const symlinkFailed = successful.filter(([, r]) => r.mode === 'symlink' && r.symlinkFailed);
     if (symlinkFailed.length > 0) {
-      const copiedAgentNames = symlinkFailed.map(([a]) => agents[a].displayName);
+      const copiedAgentNames = symlinkFailed.map(([a]) => agentDisplayName(a));
       p.log.warn(chalk.yellow(`Symlinks failed for: ${copiedAgentNames.join(', ')}`));
       p.log.message(
         chalk.dim(
@@ -953,7 +1048,7 @@ function displaySingleSkillResults(
   if (failed.length > 0) {
     p.log.error(chalk.red(`Failed to install to ${failed.length} agent(s)`));
     for (const [agent, result] of failed) {
-      p.log.message(`  ${chalk.red('✗')} ${agents[agent].displayName}: ${chalk.dim(result.error)}`);
+      p.log.message(`  ${chalk.red('✗')} ${agentDisplayName(agent)}: ${chalk.dim(result.error)}`);
     }
   }
 }

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { type AgentType, getAgentConfig, isValidAgentType } from '../../core/agent-registry.js';
 import { CLAUDE_COWORK_3P_AGENT } from '../../core/claude-3p-installer.js';
+import { ConfigLoader } from '../../core/config-loader.js';
 import { SkillManager } from '../../core/skill-manager.js';
 import { BASE_DIR_OPTION_DESCRIPTION, resolveBaseDirOrExit } from '../../utils/base-dir.js';
 import { logger } from '../../utils/logger.js';
@@ -18,22 +19,25 @@ export const listCommand = new Command('list')
   .action((options) => {
     const agentInput: string | undefined = options.agent;
 
-    if (agentInput !== undefined && !isValidAgentType(agentInput)) {
+    // claude-cowork-3p is always global
+    const preIsGlobal = options.global || agentInput === CLAUDE_COWORK_3P_AGENT;
+    const baseDir = resolveBaseDirOrExit(options.baseDir, { global: preIsGlobal });
+    const projectRoot = baseDir ?? process.cwd();
+    const customAgents = new ConfigLoader(projectRoot).getCustomAgents();
+
+    if (agentInput !== undefined && !isValidAgentType(agentInput, customAgents)) {
       logger.error(`Invalid agent: ${agentInput}`);
       process.exit(1);
     }
 
     const agent = agentInput as AgentType | undefined;
-
-    // claude-cowork-3p is always global
-    const isGlobal = options.global || agent === CLAUDE_COWORK_3P_AGENT;
-    const baseDir = resolveBaseDirOrExit(options.baseDir, { global: isGlobal });
+    const isGlobal = preIsGlobal;
     const skillManager = new SkillManager(baseDir, { global: isGlobal });
     const skills = skillManager.list(agent ? { agent } : undefined);
 
     if (skills.length === 0) {
       const location = agent
-        ? `for ${getAgentConfig(agent).displayName}`
+        ? `for ${getAgentConfig(agent, customAgents).displayName}`
         : isGlobal
           ? 'globally'
           : 'in this project';
@@ -46,7 +50,11 @@ export const listCommand = new Command('list')
       return;
     }
 
-    const scopeLabel = agent ? getAgentConfig(agent).displayName : isGlobal ? 'global' : 'project';
+    const scopeLabel = agent
+      ? getAgentConfig(agent, customAgents).displayName
+      : isGlobal
+        ? 'global'
+        : 'project';
     logger.log(`Installed Skills (${scopeLabel}):`);
     logger.newline();
 
@@ -56,7 +64,7 @@ export const listCommand = new Command('list')
       skill.isLinked ? `${skill.version} (linked)` : skill.version,
       skill.source || '-',
       skill.agents?.length
-        ? skill.agents.map((a) => getAgentConfig(a).displayName).join(', ')
+        ? skill.agents.map((a) => getAgentConfig(a, customAgents).displayName).join(', ')
         : '-',
     ]);
 

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -1,7 +1,7 @@
 import * as p from '@clack/prompts';
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { type AgentType, agents } from '../../core/agent-registry.js';
+import { type AgentType, getAgentConfig, getAllAgentTypes } from '../../core/agent-registry.js';
 import { ConfigLoader } from '../../core/config-loader.js';
 import { Installer } from '../../core/installer.js';
 import { SkillManager } from '../../core/skill-manager.js';
@@ -33,13 +33,15 @@ export const uninstallCommand = new Command('uninstall')
     // Use installDir from config to match where skills are actually installed
     const config = new ConfigLoader(projectRoot);
     const defaults = config.getDefaults();
+    const customAgents = config.getCustomAgents();
     const installer = new Installer({
       cwd: projectRoot,
       global: isGlobal,
       installDir: defaults.installDir,
+      customAgents,
     });
 
-    const allAgentTypes = Object.keys(agents) as AgentType[];
+    const allAgentTypes = getAllAgentTypes(customAgents);
 
     // Collect info for all skills
     type SkillInfo = {
@@ -78,7 +80,9 @@ export const uninstallCommand = new Command('uninstall')
     const summaryLines: string[] = [];
     for (const skill of skillsToUninstall) {
       summaryLines.push(`${chalk.cyan(skill.name)}`);
-      const agentNames = skill.installedAgents.map((a) => agents[a].displayName).join(', ');
+      const agentNames = skill.installedAgents
+        .map((a) => getAgentConfig(a, customAgents).displayName)
+        .join(', ');
       if (agentNames) {
         summaryLines.push(`  ${chalk.dim('→')} ${agentNames}`);
       }

--- a/src/core/agent-registry.test.ts
+++ b/src/core/agent-registry.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   type AgentType,
   agents,
+  buildCustomAgentConfig,
+  type CustomAgentMap,
   detectInstalledAgents,
   getAgentConfig,
   getAgentSkillsDir,
@@ -230,6 +232,98 @@ describe('agent-registry', () => {
       for (const agent of installed) {
         expect(isValidAgentType(agent)).toBe(true);
       }
+    });
+  });
+
+  describe('custom agents', () => {
+    const home = os.homedir();
+    const custom: CustomAgentMap = {
+      'cc-switch': { path: '.cc-switch/skills', globalPath: '~/.cc-switch/skills' },
+      'proj-only': { path: '.tool/skills' },
+    };
+
+    describe('buildCustomAgentConfig', () => {
+      it('should map path to skillsDir and expand ~ in globalPath', () => {
+        const config = buildCustomAgentConfig('cc-switch', custom['cc-switch']);
+        expect(config.name).toBe('cc-switch');
+        expect(config.displayName).toBe('cc-switch');
+        expect(config.skillsDir).toBe('.cc-switch/skills');
+        expect(config.globalSkillsDir).toBe(path.join(home, '.cc-switch/skills'));
+      });
+
+      it('should use displayName when provided', () => {
+        const config = buildCustomAgentConfig('x', { path: '.x/skills', displayName: 'My X' });
+        expect(config.displayName).toBe('My X');
+      });
+
+      it('should leave globalSkillsDir empty when globalPath is absent', () => {
+        const config = buildCustomAgentConfig('proj-only', custom['proj-only']);
+        expect(config.globalSkillsDir).toBe('');
+      });
+
+      it('should always report as installed', async () => {
+        const config = buildCustomAgentConfig('x', { path: '.x/skills' });
+        expect(await config.detectInstalled()).toBe(true);
+      });
+    });
+
+    describe('isValidAgentType with custom', () => {
+      it('should accept a custom alias when passed the map', () => {
+        expect(isValidAgentType('cc-switch', custom)).toBe(true);
+      });
+
+      it('should reject a custom alias when no map is passed', () => {
+        expect(isValidAgentType('cc-switch')).toBe(false);
+      });
+
+      it('should still accept built-in agents', () => {
+        expect(isValidAgentType('claude-code', custom)).toBe(true);
+      });
+    });
+
+    describe('getAgentConfig with custom', () => {
+      it('should resolve a custom agent', () => {
+        expect(getAgentConfig('cc-switch', custom).skillsDir).toBe('.cc-switch/skills');
+      });
+
+      it('should throw for an unknown agent', () => {
+        expect(() => getAgentConfig('nope', custom)).toThrow(/Unknown agent type/);
+      });
+    });
+
+    describe('getAgentSkillsDir with custom', () => {
+      it('should resolve a project-level custom directory', () => {
+        const dir = getAgentSkillsDir('cc-switch', { cwd: '/proj', custom });
+        expect(dir).toBe(path.join('/proj', '.cc-switch/skills'));
+      });
+
+      it('should resolve a global custom directory', () => {
+        const dir = getAgentSkillsDir('cc-switch', { global: true, custom });
+        expect(dir).toBe(path.join(home, '.cc-switch/skills'));
+      });
+
+      it('should throw for global install without globalPath', () => {
+        expect(() => getAgentSkillsDir('proj-only', { global: true, custom })).toThrow(
+          /no globalPath configured/,
+        );
+      });
+    });
+
+    describe('getAllAgentTypes with custom', () => {
+      it('should append custom aliases', () => {
+        const all = getAllAgentTypes(custom);
+        expect(all).toContain('cc-switch');
+        expect(all).toContain('proj-only');
+        expect(all.length).toBe(Object.keys(agents).length + 2);
+      });
+    });
+
+    describe('detectInstalledAgents with custom', () => {
+      it('should always include custom aliases', async () => {
+        const installed = await detectInstalledAgents(custom);
+        expect(installed).toContain('cc-switch');
+        expect(installed).toContain('proj-only');
+      });
     });
   });
 });

--- a/src/core/agent-registry.ts
+++ b/src/core/agent-registry.ts
@@ -15,9 +15,9 @@ import {
 } from './claude-3p-installer.js';
 
 /**
- * Supported Agent types
+ * Built-in Agent types
  */
-export type AgentType =
+export type BuiltinAgentType =
   | 'amp'
   | 'antigravity'
   | 'claude-code'
@@ -36,6 +36,33 @@ export type AgentType =
   | 'trae'
   | 'windsurf'
   | 'neovate';
+
+/**
+ * Agent type identifier.
+ *
+ * Accepts the built-in agents (with editor autocompletion via the literal
+ * union) as well as arbitrary custom agent aliases defined in skills.json.
+ * The `string & {}` branch keeps the literal suggestions while still allowing
+ * any user-defined alias to type-check.
+ */
+export type AgentType = BuiltinAgentType | (string & {});
+
+/**
+ * Custom agent configuration as declared in skills.json.
+ */
+export interface CustomAgentConfig {
+  /** Project-level skills directory (relative to project root) */
+  path: string;
+  /** Global skills directory (absolute; supports `~` for the home directory) */
+  globalPath?: string;
+  /** Optional display name; defaults to the alias */
+  displayName?: string;
+}
+
+/**
+ * Map of custom agent alias -> configuration.
+ */
+export type CustomAgentMap = Record<string, CustomAgentConfig>;
 
 /**
  * Agent configuration interface
@@ -58,7 +85,7 @@ const home = homedir();
 /**
  * All supported Agents configuration
  */
-export const agents: Record<AgentType, AgentConfig> = {
+export const agents: Record<BuiltinAgentType, AgentConfig> = {
   amp: {
     name: 'amp',
     displayName: 'Amp',
@@ -231,16 +258,52 @@ export const agents: Record<AgentType, AgentConfig> = {
 };
 
 /**
- * Get all Agent type list
+ * Expand a leading `~` to the user's home directory.
  */
-export function getAllAgentTypes(): AgentType[] {
-  return Object.keys(agents) as AgentType[];
+function expandHome(p: string): string {
+  if (p === '~') {
+    return home;
+  }
+  if (p.startsWith('~/')) {
+    return join(home, p.slice(2));
+  }
+  return p;
 }
 
 /**
- * Detect installed Agents
+ * Build an AgentConfig from a custom agent declaration.
+ *
+ * Custom agents reuse the same AgentConfig shape as built-ins, so all
+ * downstream path resolution works unchanged. `globalSkillsDir` is only
+ * available when the declaration provides `globalPath`; consumers must guard
+ * global installs when it is empty.
  */
-export async function detectInstalledAgents(): Promise<AgentType[]> {
+export function buildCustomAgentConfig(name: string, cfg: CustomAgentConfig): AgentConfig {
+  return {
+    name,
+    displayName: cfg.displayName ?? name,
+    skillsDir: cfg.path,
+    globalSkillsDir: cfg.globalPath ? expandHome(cfg.globalPath) : '',
+    detectInstalled: async () => true,
+  };
+}
+
+/**
+ * Get all Agent type list, including custom agents when provided.
+ */
+export function getAllAgentTypes(custom?: CustomAgentMap): AgentType[] {
+  const builtin = Object.keys(agents) as AgentType[];
+  if (!custom) {
+    return builtin;
+  }
+  return [...builtin, ...Object.keys(custom)];
+}
+
+/**
+ * Detect installed Agents. Custom agents are always considered installed,
+ * since their target directory is declared explicitly by the user.
+ */
+export async function detectInstalledAgents(custom?: CustomAgentMap): Promise<AgentType[]> {
   const installed: AgentType[] = [];
 
   for (const [type, config] of Object.entries(agents)) {
@@ -249,21 +312,35 @@ export async function detectInstalledAgents(): Promise<AgentType[]> {
     }
   }
 
+  if (custom) {
+    installed.push(...Object.keys(custom));
+  }
+
   return installed;
 }
 
 /**
- * Get Agent configuration
+ * Get Agent configuration.
+ *
+ * Resolves built-in agents first, then custom agents from the provided map.
+ * Throws when the type is neither built-in nor a known custom agent.
  */
-export function getAgentConfig(type: AgentType): AgentConfig {
-  return agents[type];
+export function getAgentConfig(type: AgentType, custom?: CustomAgentMap): AgentConfig {
+  if (type in agents) {
+    return agents[type as BuiltinAgentType];
+  }
+  const customCfg = custom?.[type];
+  if (customCfg) {
+    return buildCustomAgentConfig(type, customCfg);
+  }
+  throw new Error(`Unknown agent type: "${type}"`);
 }
 
 /**
- * Validate if Agent type is valid
+ * Validate if Agent type is valid (built-in or a known custom agent).
  */
-export function isValidAgentType(type: string): type is AgentType {
-  return type in agents;
+export function isValidAgentType(type: string, custom?: CustomAgentMap): boolean {
+  return type in agents || (custom ? type in custom : false);
 }
 
 /**
@@ -275,13 +352,18 @@ export function isValidAgentType(type: string): type is AgentType {
  */
 export function getAgentSkillsDir(
   type: AgentType,
-  options: { global?: boolean; cwd?: string } = {},
+  options: { global?: boolean; cwd?: string; custom?: CustomAgentMap } = {},
 ): string {
-  const config = agents[type];
   if (type === CLAUDE_COWORK_3P_AGENT) {
     return join(resolveClaude3pSkillsRoot(), 'skills');
   }
+  const config = getAgentConfig(type, options.custom);
   if (options.global) {
+    if (!config.globalSkillsDir) {
+      throw new Error(
+        `Custom agent "${type}" has no globalPath configured; cannot install globally`,
+      );
+    }
     return config.globalSkillsDir;
   }
   const cwd = options.cwd || process.cwd();

--- a/src/core/config-loader.test.ts
+++ b/src/core/config-loader.test.ts
@@ -396,6 +396,64 @@ describe('ConfigLoader', () => {
     });
   });
 
+  describe('getCustomAgents', () => {
+    it('should return an empty map when no config exists', () => {
+      expect(configLoader.getCustomAgents()).toEqual({});
+    });
+
+    it('should return an empty map when customAgents is absent', () => {
+      const testConfig: SkillsJson = { skills: {} };
+      fs.writeFileSync(path.join(tempDir, 'skills.json'), JSON.stringify(testConfig));
+      const loader = new ConfigLoader(tempDir);
+      expect(loader.getCustomAgents()).toEqual({});
+    });
+
+    it('should read custom agents from skills.json', () => {
+      const testConfig: SkillsJson = {
+        skills: {},
+        customAgents: {
+          'cc-switch': { path: '.cc-switch/skills', globalPath: '~/.cc-switch/skills' },
+        },
+      };
+      fs.writeFileSync(path.join(tempDir, 'skills.json'), JSON.stringify(testConfig));
+
+      const loader = new ConfigLoader(tempDir);
+      const custom = loader.getCustomAgents();
+      expect(custom['cc-switch']).toEqual({
+        path: '.cc-switch/skills',
+        globalPath: '~/.cc-switch/skills',
+      });
+    });
+  });
+
+  describe('updateCustomAgents', () => {
+    it('should persist custom agents to skills.json', () => {
+      configLoader.create();
+      configLoader.updateCustomAgents({ 'cc-switch': { path: '.cc-switch/skills' } });
+
+      const reloaded = new ConfigLoader(tempDir);
+      expect(reloaded.getCustomAgents()).toEqual({
+        'cc-switch': { path: '.cc-switch/skills' },
+      });
+    });
+
+    it('should merge without dropping existing custom agents', () => {
+      configLoader.create({ customAgents: { existing: { path: '.existing/skills' } } });
+      configLoader.updateCustomAgents({ 'cc-switch': { path: '.cc-switch/skills' } });
+
+      const reloaded = new ConfigLoader(tempDir);
+      const custom = reloaded.getCustomAgents();
+      expect(custom.existing).toEqual({ path: '.existing/skills' });
+      expect(custom['cc-switch']).toEqual({ path: '.cc-switch/skills' });
+    });
+
+    it('should be a no-op for an empty update', () => {
+      configLoader.create();
+      configLoader.updateCustomAgents({});
+      expect(new ConfigLoader(tempDir).getCustomAgents()).toEqual({});
+    });
+  });
+
   describe('getRegistries', () => {
     it('should return default registries when no config', () => {
       const registries = configLoader.getRegistries();

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path';
 import type { SkillsDefaults, SkillsJson } from '../types/index.js';
 import { exists, getSkillsJsonPath, readJson, writeJson } from '../utils/fs.js';
+import type { CustomAgentMap } from './agent-registry.js';
 
 // ============================================================================
 // Constants
@@ -107,7 +108,7 @@ export class ConfigLoader {
   /**
    * Enable/disable no-manifest mode.
    * When enabled, all write operations (save, create, addSkill, updateDefaults,
-   * addRegistry) become no-ops. Read operations are unaffected.
+   * updateCustomAgents, addRegistry) become no-ops. Read operations are unaffected.
    */
   setNoManifest(enabled: boolean): void {
     this._noManifest = enabled;
@@ -265,6 +266,43 @@ export class ConfigLoader {
     if (this.config) {
       this.config.defaults = {
         ...this.config.defaults,
+        ...updates,
+      };
+      this.save();
+    }
+  }
+
+  // ==========================================================================
+  // Custom Agents
+  // ==========================================================================
+
+  /**
+   * Get custom agent targets declared in skills.json.
+   *
+   * Returns an empty map when none are configured.
+   */
+  getCustomAgents(): CustomAgentMap {
+    const config = this.getConfigOrDefault();
+    return { ...config.customAgents };
+  }
+
+  /**
+   * Merge custom agent targets into skills.json and save.
+   *
+   * Existing aliases are preserved unless the update overrides them. Callers
+   * are responsible for ensuring aliases do not collide with built-in agent
+   * names (the CLI parser guarantees this for `-a alias:path`).
+   *
+   * @param updates - Map of alias -> configuration to merge in
+   */
+  updateCustomAgents(updates: CustomAgentMap): void {
+    if (this._noManifest) return;
+    if (Object.keys(updates).length === 0) return;
+    this.ensureConfigLoaded();
+
+    if (this.config) {
+      this.config.customAgents = {
+        ...this.config.customAgents,
         ...updates,
       };
       this.save();

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,7 +1,14 @@
-export type { AgentConfig, AgentType } from './agent-registry.js';
+export type {
+  AgentConfig,
+  AgentType,
+  BuiltinAgentType,
+  CustomAgentConfig,
+  CustomAgentMap,
+} from './agent-registry.js';
 // Multi-Agent support
 export {
   agents,
+  buildCustomAgentConfig,
   detectInstalledAgents,
   getAgentConfig,
   getAgentSkillsDir,

--- a/src/core/install-directory.ts
+++ b/src/core/install-directory.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { type AgentType, agents } from './agent-registry.js';
+import { agents, type BuiltinAgentType } from './agent-registry.js';
 
 /**
  * Default skills directory when no AI tool is detected
@@ -18,7 +18,7 @@ export const DEFAULT_SKILLS_DIR = '.skills';
  * Agent priority order for detection
  * 当多个 agent 目录同时存在时，按此顺序选择
  */
-const AGENT_PRIORITY: AgentType[] = [
+const AGENT_PRIORITY: BuiltinAgentType[] = [
   'claude-code', // .claude
   'cursor', // .cursor
   'windsurf', // .windsurf
@@ -110,7 +110,7 @@ export async function detectInstallDirectory(options: DetectOptions = {}): Promi
  * @param baseDir - Base project directory
  * @returns Agent base directory path or null if not applicable
  */
-function getAgentBaseDir(agentType: AgentType, baseDir: string): string | null {
+function getAgentBaseDir(agentType: BuiltinAgentType, baseDir: string): string | null {
   const config = agents[agentType];
   const skillsDir = config.skillsDir;
 

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -11,7 +11,7 @@
 import * as fs from 'node:fs';
 import { homedir, platform } from 'node:os';
 import * as path from 'node:path';
-import type { AgentType } from './agent-registry.js';
+import type { AgentType, CustomAgentMap } from './agent-registry.js';
 import { getAgentConfig } from './agent-registry.js';
 import {
   CLAUDE_COWORK_3P_AGENT,
@@ -57,6 +57,8 @@ export interface InstallerOptions {
   mode?: InstallMode;
   /** Custom installation directory (relative to cwd), overrides default .agents/skills */
   installDir?: string;
+  /** Custom agent targets (alias -> directory configuration) */
+  customAgents?: CustomAgentMap;
 }
 
 const AGENTS_DIR = '.agents';
@@ -237,11 +239,13 @@ export class Installer {
   private cwd: string;
   private isGlobal: boolean;
   private installDir?: string;
+  private customAgents?: CustomAgentMap;
 
-  constructor(options: { cwd?: string; global?: boolean; installDir?: string } = {}) {
+  constructor(options: InstallerOptions = {}) {
     this.cwd = options.cwd || process.cwd();
     this.isGlobal = options.global || false;
     this.installDir = options.installDir;
+    this.customAgents = options.customAgents;
   }
 
   /**
@@ -261,7 +265,7 @@ export class Installer {
       return getClaude3pSkillPath(skillName);
     }
 
-    const agent = getAgentConfig(agentType);
+    const agent = getAgentConfig(agentType, this.customAgents);
     const sanitized = sanitizeName(skillName);
     const agentBase = this.isGlobal ? agent.globalSkillsDir : path.join(this.cwd, agent.skillsDir);
     return path.join(agentBase, sanitized);
@@ -285,7 +289,7 @@ export class Installer {
       return installClaude3pSkill(sourcePath, skillName, { mode: options.mode });
     }
 
-    const agent = getAgentConfig(agentType);
+    const agent = getAgentConfig(agentType, this.customAgents);
     const installMode = options.mode || 'symlink';
     const sanitized = sanitizeName(skillName);
 
@@ -294,6 +298,14 @@ export class Installer {
     const canonicalDir = path.join(canonicalBase, sanitized);
 
     // Agent specific location
+    if (this.isGlobal && !agent.globalSkillsDir) {
+      return {
+        success: false,
+        path: '',
+        mode: installMode,
+        error: `Custom agent "${agentType}" has no globalPath configured; cannot install globally`,
+      };
+    }
     const agentBase = this.isGlobal ? agent.globalSkillsDir : path.join(this.cwd, agent.skillsDir);
     const agentDir = path.join(agentBase, sanitized);
 
@@ -479,10 +491,10 @@ export class Installer {
       }
     }
 
-    const agent = getAgentConfig(agentType);
+    const agent = getAgentConfig(agentType, this.customAgents);
     const skillsDir = this.isGlobal ? agent.globalSkillsDir : path.join(this.cwd, agent.skillsDir);
 
-    if (!fs.existsSync(skillsDir)) {
+    if (!skillsDir || !fs.existsSync(skillsDir)) {
       return [];
     }
 

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -32,7 +32,10 @@ import {
 import {
   type AgentType,
   agents,
+  buildCustomAgentConfig,
+  type CustomAgentMap,
   detectInstalledAgents,
+  getAllAgentTypes,
   isValidAgentType,
 } from './agent-registry.js';
 import { CacheManager } from './cache-manager.js';
@@ -117,10 +120,7 @@ export interface SourceMeta {
   installedAt: string;
 }
 
-export function writeSourceMeta(
-  skillDir: string,
-  meta: Omit<SourceMeta, 'installedAt'>,
-): void {
+export function writeSourceMeta(skillDir: string, meta: Omit<SourceMeta, 'installedAt'>): void {
   const data: SourceMeta = {
     ...meta,
     installedAt: new Date().toISOString(),
@@ -146,6 +146,12 @@ export interface SkillManagerOptions {
   global?: boolean;
   /** Skip all skills.json and skills.lock writes (platform integration mode) */
   noManifest?: boolean;
+  /**
+   * Ephemeral custom agent targets not persisted in skills.json.
+   * Merged over (and taking precedence on conflict with) skills.json's
+   * customAgents. Used for CLI `-a alias:path` one-off targets.
+   */
+  customAgents?: CustomAgentMap;
 }
 
 /**
@@ -167,10 +173,12 @@ export class SkillManager {
   private config: ConfigLoader;
   private lockManager: LockManager;
   private isGlobal: boolean;
+  private ephemeralCustomAgents: CustomAgentMap;
 
   constructor(projectRoot?: string, options?: SkillManagerOptions) {
     this.projectRoot = projectRoot || process.cwd();
     this.isGlobal = options?.global || false;
+    this.ephemeralCustomAgents = options?.customAgents ?? {};
     this.config = new ConfigLoader(this.projectRoot);
     this.lockManager = new LockManager(this.projectRoot);
     this.cache = new CacheManager();
@@ -203,6 +211,14 @@ export class SkillManager {
   }
 
   /**
+   * Resolve the effective custom agents: skills.json declarations merged with
+   * ephemeral CLI-provided targets (the latter win on alias conflict).
+   */
+  private getCustomAgents(): CustomAgentMap {
+    return { ...this.config.getCustomAgents(), ...this.ephemeralCustomAgents };
+  }
+
+  /**
    * Determine if the installation is effectively global.
    *
    * Claude Cowork 3P always installs to a global app-managed directory regardless
@@ -211,9 +227,7 @@ export class SkillManager {
    */
   private isEffectivelyGlobal(targetAgents: AgentType[]): boolean {
     if (this.isGlobal) return true;
-    return (
-      targetAgents.length > 0 && targetAgents.every((a) => a === CLAUDE_COWORK_3P_AGENT)
-    );
+    return targetAgents.length > 0 && targetAgents.every((a) => a === CLAUDE_COWORK_3P_AGENT);
   }
 
   /**
@@ -732,9 +746,7 @@ export class SkillManager {
     const targetAgents = await detectInstalledAgents();
     const updated: InstalledSkill[] = [];
 
-    const skillsToUpdate = name
-      ? installed.filter((s) => s.name === name)
-      : installed;
+    const skillsToUpdate = name ? installed.filter((s) => s.name === name) : installed;
 
     if (name && skillsToUpdate.length === 0) {
       logger.error(`Skill ${name} not found in global skills`);
@@ -750,7 +762,9 @@ export class SkillManager {
       // Read source metadata
       const sourceMeta = readSourceMeta(skill.path);
       if (!sourceMeta?.source) {
-        logger.warn(`${skill.name}: no source metadata, skipping (run 'reskill outdated -g' first to detect sources)`);
+        logger.warn(
+          `${skill.name}: no source metadata, skipping (run 'reskill outdated -g' first to detect sources)`,
+        );
         continue;
       }
 
@@ -970,6 +984,7 @@ export class SkillManager {
     const installer = new Installer({
       cwd: this.projectRoot,
       global: this.isGlobal,
+      customAgents: this.getCustomAgents(),
     });
 
     const skillNames = installer.listInstalledSkills(agent);
@@ -999,8 +1014,17 @@ export class SkillManager {
    */
   private detectSkillAgents(skillName: string): AgentType[] {
     const canonicalDir = this.getCanonicalSkillsDir();
+    const custom = this.getCustomAgents();
     const installed: AgentType[] = [];
-    for (const [type, config] of Object.entries(agents)) {
+
+    const builtinConfigs = Object.entries(agents) as Array<
+      [AgentType, (typeof agents)[keyof typeof agents]]
+    >;
+    const customConfigs = Object.entries(custom).map(
+      ([type, cfg]) => [type, buildCustomAgentConfig(type, cfg)] as const,
+    );
+
+    for (const [type, config] of [...builtinConfigs, ...customConfigs]) {
       if (type === CLAUDE_COWORK_3P_AGENT) {
         try {
           if (exists(getClaude3pSkillPath(skillName))) {
@@ -1015,6 +1039,11 @@ export class SkillManager {
       const agentBase = this.isGlobal
         ? config.globalSkillsDir
         : path.join(this.projectRoot, config.skillsDir);
+
+      // Custom agents without a globalPath have no global location to inspect
+      if (!agentBase) {
+        continue;
+      }
 
       // Skip agents whose skillsDir is the canonical directory itself
       if (path.resolve(agentBase) === path.resolve(canonicalDir)) {
@@ -1254,7 +1283,12 @@ export class SkillManager {
       }
 
       // Unscoped global skills — probe known registries with @scope/name
-      const probed = await this.probeRegistriesForSkill(skill.name, currentVersion, scopeUrls, skill.path);
+      const probed = await this.probeRegistriesForSkill(
+        skill.name,
+        currentVersion,
+        scopeUrls,
+        skill.path,
+      );
       results.push(probed);
     }
 
@@ -1337,7 +1371,12 @@ export class SkillManager {
       }
     }
 
-    return { name, current: currentVersion, latest: 'n/a (unknown source)', updateAvailable: false };
+    return {
+      name,
+      current: currentVersion,
+      latest: 'n/a (unknown source)',
+      updateAvailable: false,
+    };
   }
 
   /**
@@ -1539,6 +1578,7 @@ export class SkillManager {
       cwd: this.projectRoot,
       global: this.isGlobal,
       installDir: customInstallDir,
+      customAgents: this.getCustomAgents(),
     });
 
     const installed: Array<{
@@ -1668,6 +1708,7 @@ export class SkillManager {
       cwd: this.projectRoot,
       global: this.isGlobal,
       installDir: defaults.installDir,
+      customAgents: this.getCustomAgents(),
     });
 
     // Install to all target agents
@@ -1777,6 +1818,7 @@ export class SkillManager {
       cwd: this.projectRoot,
       global: this.isGlobal,
       installDir: defaults.installDir,
+      customAgents: this.getCustomAgents(),
     });
 
     // Install to all target agents
@@ -1921,6 +1963,7 @@ export class SkillManager {
         cwd: this.projectRoot,
         global: this.isGlobal,
         installDir: defaults.installDir,
+        customAgents: this.getCustomAgents(),
       });
 
       const missingAgents = targetAgents.filter(
@@ -2014,6 +2057,7 @@ export class SkillManager {
         cwd: this.projectRoot,
         global: this.isGlobal,
         installDir: defaults.installDir,
+        customAgents: this.getCustomAgents(),
       });
 
       // 6. Install to all target agents
@@ -2272,6 +2316,7 @@ export class SkillManager {
         cwd: this.projectRoot,
         global: this.isGlobal,
         installDir: defaults.installDir,
+        customAgents: this.getCustomAgents(),
       });
       const results = await installer.installToAgents(extractedPath, shortName, targetAgents, {
         mode: mode as InstallMode,
@@ -2343,14 +2388,15 @@ export class SkillManager {
    * 3. Return empty array
    */
   async getDefaultTargetAgents(): Promise<AgentType[]> {
+    const custom = this.getCustomAgents();
     // Read from configuration
     const defaults = this.config.getDefaults();
     if (defaults.targetAgents && defaults.targetAgents.length > 0) {
-      return defaults.targetAgents.filter(isValidAgentType) as AgentType[];
+      return defaults.targetAgents.filter((a) => isValidAgentType(a, custom)) as AgentType[];
     }
 
     // Auto-detect
-    return detectInstalledAgents();
+    return detectInstalledAgents(custom);
   }
 
   /**
@@ -2368,11 +2414,12 @@ export class SkillManager {
    * Validate agent type list
    */
   validateAgentTypes(agentNames: string[]): { valid: AgentType[]; invalid: string[] } {
+    const custom = this.getCustomAgents();
     const valid: AgentType[] = [];
     const invalid: string[] = [];
 
     for (const name of agentNames) {
-      if (isValidAgentType(name)) {
+      if (isValidAgentType(name, custom)) {
         valid.push(name);
       } else {
         invalid.push(name);
@@ -2386,7 +2433,7 @@ export class SkillManager {
    * Get all available agent types
    */
   getAllAgentTypes(): AgentType[] {
-    return Object.keys(agents) as AgentType[];
+    return getAllAgentTypes(this.getCustomAgents());
   }
 
   /**
@@ -2398,6 +2445,7 @@ export class SkillManager {
       cwd: this.projectRoot,
       global: this.isGlobal,
       installDir: defaults.installDir,
+      customAgents: this.getCustomAgents(),
     });
 
     const results = installer.uninstallFromAgents(name, targetAgents);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@
 export {
   // Multi-Agent support
   agents,
+  buildCustomAgentConfig,
   CacheManager,
   ConfigLoader,
   // Content scanning
@@ -44,6 +45,9 @@ export type {
   AgentConfig,
   // Multi-Agent types
   AgentType,
+  BuiltinAgentType,
+  CustomAgentConfig,
+  CustomAgentMap,
   InstalledSkill,
   InstallMode,
   InstallOptions,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,13 @@
  * Based on: docs/skills-management-design.md
  */
 
-import type { AgentConfig, AgentType } from '../core/agent-registry.js';
+import type {
+  AgentConfig,
+  AgentType,
+  BuiltinAgentType,
+  CustomAgentConfig,
+  CustomAgentMap,
+} from '../core/agent-registry.js';
 
 // ============================================================================
 // Multi-Agent related types
@@ -12,20 +18,7 @@ import type { AgentConfig, AgentType } from '../core/agent-registry.js';
 /**
  * Supported Agent types
  */
-export type { AgentConfig, AgentType };
-
-/**
- * Installation mode
- */
-export type { InstallMode, InstallResult } from '../core/installer.js';
-
-/**
- * SKILL.md parsing related types (following agentskills.io specification)
- */
-export type {
-  ParsedSkill,
-  SkillMdFrontmatter,
-} from '../core/skill-parser.js';
+export type { AgentConfig, AgentType, BuiltinAgentType, CustomAgentConfig, CustomAgentMap };
 
 /**
  * Content scanning types
@@ -38,6 +31,17 @@ export type {
   ScanRule,
   ScanRuleMatch,
 } from '../core/content-scanner.js';
+/**
+ * Installation mode
+ */
+export type { InstallMode, InstallResult } from '../core/installer.js';
+/**
+ * SKILL.md parsing related types (following agentskills.io specification)
+ */
+export type {
+  ParsedSkill,
+  SkillMdFrontmatter,
+} from '../core/skill-parser.js';
 
 // ============================================================================
 // skills.json - Project dependency configuration
@@ -106,6 +110,8 @@ export interface SkillsJson {
   defaults?: SkillsDefaults;
   /** Skill override configuration */
   overrides?: Record<string, SkillOverride>;
+  /** Custom agent targets (alias -> directory configuration) */
+  customAgents?: CustomAgentMap;
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #381

## What

Adds support for installing skills into directories that are **not** part of the built-in agent table (the 18 hardcoded agents like `claude-code`, `cursor`). Two entry points:

**1. Declarative — `customAgents` in `skills.json`:**
```json
{
  "defaults": { "targetAgents": ["claude-code", "cc-switch"] },
  "customAgents": {
    "cc-switch": { "path": ".cc-switch/skills", "globalPath": "~/.cc-switch/skills" }
  }
}
```

**2. Ad-hoc — CLI `-a alias:path`:**
```bash
reskill install github:user/skill -a cc-switch:.cc-switch/skills
# → alias is persisted into skills.json customAgents on a successful project install
```

The custom alias works anywhere a built-in agent name is accepted: `-a`, `defaults.targetAgents`, `list -a`, `uninstall`, `doctor`, and shell completion. Both project-level and global (`-g`, requires `globalPath`) installs are supported.

## Why

`reskill`'s agent targets were a hardcoded table; `-a` and `targetAgents` could only pick from it, and `AgentType` was a closed union. Users maintaining a personal skills repo who symlink into arbitrary tool directories (e.g. `.cc-switch/skills`) had no way to manage those as reskill targets. This is orthogonal to `--base-dir` (#354), which relocates the project *root* but keeps each agent's built-in layout.

## How

All agent path resolution already funnels through a single `AgentConfig` shape and `getAgentConfig()` lookup. Custom agents reuse that exact shape (built from config), so the `isGlobal ? globalSkillsDir : join(cwd, skillsDir)` path logic is unchanged. The resolver functions (`getAgentConfig` / `isValidAgentType` / `getAgentSkillsDir` / `getAllAgentTypes` / `detectInstalledAgents`) now take an optional `customAgents` map, threaded from `ConfigLoader` through `SkillManager` (with an ephemeral CLI-provided overlay) into `Installer`. `AgentType` is widened to `BuiltinAgentType | (string & {})`.

- `path` — project-relative directory (required)
- `globalPath` — absolute directory (leading `~` expands to home) for `-g`; global install without it is rejected with a clear error
- `doctor` validates `customAgents` entries and no longer flags custom aliases in `targetAgents` as unknown

## Testing

- Unit: `agent-registry` (14), `config-loader` (6, incl. `updateCustomAgents`), `completion` mock updated
- Integration: new `install-custom-agents.test.ts` (9) — declared config install/list/uninstall, CLI `alias:path`, persistence, reinstall reuse, global with/without `globalPath`, built-in regression
- Full suite: 1596 unit passed, 285 integration passed, typecheck + lint clean
- Manually verified end-to-end against a real registry skill (`@kanyun/zebrain-episode-cli`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)